### PR TITLE
Problem: configuration file has wrong name and no content

### DIFF
--- a/src/fty-alert-engine.conf
+++ b/src/fty-alert-engine.conf
@@ -1,0 +1,2 @@
+d /var/lib/fty/fty_alert_engine 0755 bios root
+x /var/lib/fty/fty_alert_engine/*


### PR DESCRIPTION
Solution: rename and specify directories

Signed-off-by: Tomas Halman <TomasHalman@eaton.com>