### PR TITLE
Problem: Warranty rule is not installed where fty-alert-engine expect…

### DIFF
--- a/packaging/debian/fty-alert-engine.install
+++ b/packaging/debian/fty-alert-engine.install
@@ -2,4 +2,5 @@ usr/bin/fty-alert-engine
 usr/share/man/man1/fty-alert-engine.1
 etc/fty-alert-engine/fty-alert-engine.cfg
 lib/systemd/system/fty-alert-engine{,@*}.{service,*}
+var/lib/fty/fty-alert-engine/warranty.rule
 


### PR DESCRIPTION
…s it.

Solution: Add it to install file.

Signed-off-by: Jana Rapava <janarapava@eaton.com>