### PR TITLE
Problem: GNU C++ on some systems has a problem with isnan()

### DIFF
--- a/src/luarule.cc
+++ b/src/luarule.cc
@@ -90,7 +90,7 @@ int LuaRule::evaluate (const MetricList &metricList, PureAlert &pureAlert)
     std::vector<double> values;
     for ( const auto &metric : _metrics ) {
         double value = metricList.find (metric);
-        if ( isnan (value) ) {
+        if ( std::isnan (value) ) {
             //zsys_debug1("Don't have everything for '%s' yet\n", _name.c_str());
             return RULE_RESULT_UNKNOWN;
         }

--- a/src/ruleconfigurator.cc
+++ b/src/ruleconfigurator.cc
@@ -131,7 +131,7 @@ std::string escape (const std::string& before) {
 
 std::string jsonify (double t)
 {
-    if (isnan(t))
+    if (std::isnan(t))
         return "null";
     return std::to_string (t);
 }


### PR DESCRIPTION
Solution: There is a mixup between macros from <math.h> and templates from <cmath>, so use std::isnan() as recommended In The Net.