### PR TITLE
Problem: code uses absent /var/lib/fty/fty-autoconfig dir

### DIFF
--- a/src/autoconfig.cc
+++ b/src/autoconfig.cc
@@ -48,9 +48,9 @@ extern int agent_alert_verbose;
 
 #define AUTOCONFIG "AUTOCONFIG"
 
-const std::string Autoconfig::StateFilePath = "/var/lib/fty/fty-autoconfig";
+const std::string Autoconfig::StateFilePath = "/var/lib/fty/fty-alert-engine";
 std::string Autoconfig::RuleFilePath;
-const std::string Autoconfig::StateFile = "/var/lib/fty/fty-autoconfig/state";
+const std::string Autoconfig::StateFile = "/var/lib/fty/fty-alert-engine/state";
 std::string Autoconfig::AlertEngineName;
 
 static int


### PR DESCRIPTION
Solution: Since this is autoconfig for alert-engine, use its existing directory.