### PR TITLE
Problem: MB replies come out of order and unit tests are failing

### DIFF
--- a/src/fty_alert_actions.cc
+++ b/src/fty_alert_actions.cc
@@ -51,53 +51,94 @@
 
 //  Some stuff for testing purposes
 //  to access test variables other than testing, use corresponding macro
+#if !defined(MLM_MAKE_VERSION) || !defined(MLM_VERSION)
+#error "MLM_MAKE_VERSION macro not defined"
+#endif
+#if MLM_MAKE_VERSION(1,1,0) != MLM_VERSION
+#error "MLM version has changed, please check function signatures are matching for testing framework"
+#endif
 #define TEST_VARS \
-    zlist_t *testing_recv = NULL; \
-    int testing_send = 0; \
-    char *testing_uuid = NULL;
-    char *testing_subject = NULL;
+    zlist_t *testing_var_recv = NULL; \
+    int testing_var_send = 0; \
+    char *testing_var_uuid = NULL; \
+    char *testing_var_subject = NULL;
+#define TEST_FUNCTIONS \
+    int testing_fun_sendto(long int line, const char *func, mlm_client_t *client, const char *address, \
+            const char *subject, void *tracker, uint32_t timeout, zmsg_t **msg) { \
+        assert(client); /* prevent not-used warning */ \
+        assert(tracker || !tracker); /* prevent not-used warning */ \
+        assert(timeout >= 0); /* prevent not-used warning */ \
+        zsys_debug("%s: called testing sendto on line %ld, function %s for client %s with subject %s", \
+                __FILE__, line, func, address, subject); \
+        zmsg_destroy(msg); \
+        return testing_var_send; \
+    } \
+    int testing_fun_sendtox(long int line, const char *func, mlm_client_t *client, const char *address, \
+            const char *subject, ...) { \
+        assert(client); \
+        zsys_debug("%s: called testing sendtox on line %ld, function %s for client %s with subject %s", \
+                __FILE__, line, func, address, subject); \
+        return testing_var_send; \
+    } \
+    zmsg_t * testing_fun_recv(long int line, const char *func, mlm_client_t *client) { \
+        assert(client); \
+        zsys_debug("%s: called testing recv on line %ld, function %s", __FILE__, line, func); \
+        return (zmsg_t *)zlist_pop(testing_var_recv); \
+    } \
+    void * testing_fun_wait(long int line, const char *func) { \
+        zsys_debug("%s: called testing wait on line %ld, function %s", __FILE__, line, func); \
+        return (void *)(0 == zlist_size(testing_var_recv) ? NULL : (void *)1); \
+    }
 #ifdef __GNUC__
     #define unlikely(x) __builtin_expect(0 != x, 0)
 #else
     #define unlikely(x) (0 != x)
 #endif
-#define mlm_client_recv(...) \
-    (unlikely(testing) ? ((zmsg_t *)zlist_pop(testing_recv)) : mlm_client_recv(__VA_ARGS__))
-#define mlm_client_sendtox(...) \
-    (unlikely(testing) ? (testing_send) : mlm_client_sendtox(__VA_ARGS__))
-#define mlm_client_sendto(...)  \
-    (unlikely(testing) ? (testing_send) : mlm_client_sendto(__VA_ARGS__))
+#define zpoller_wait(...) \
+    (unlikely(testing) ? (testing_fun_wait(__LINE__,__FUNCTION__)) : (zpoller_wait(__VA_ARGS__)))
+#define mlm_client_recv(a) \
+    (unlikely(testing) ? (testing_fun_recv(__LINE__,__FUNCTION__,a)) : (mlm_client_recv(a)))
+#define mlm_client_sendtox(a,b,c,...) \
+    (unlikely(testing) ? (testing_fun_sendtox(__LINE__,__FUNCTION__,a,b,c,__VA_ARGS__)) : (mlm_client_sendtox(a,b,c,__VA_ARGS__)))
+#define mlm_client_sendto(a,b,c,d,e,f)  \
+    (unlikely(testing) ? (testing_fun_sendto(__LINE__,__FUNCTION__,a,b,c,d,e,f)) : (mlm_client_sendto(a,b,c,d,e,f)))
 #define zuuid_str_canonical(...) \
-    (unlikely(testing) ? (testing_uuid) : zuuid_str_canonical(__VA_ARGS__))
+    (unlikely(testing) ? (testing_var_uuid) : (zuuid_str_canonical(__VA_ARGS__)))
 #define mlm_client_subject(...) \
-    (unlikely(testing) ? (testing_subject) : mlm_client_subject(__VA_ARGS__))
+    (unlikely(testing) ? (testing_var_subject) : (mlm_client_subject(__VA_ARGS__)))
 #define CLEAN_RECV { \
-        zmsg_t *l = (zmsg_t *) zlist_first(testing_recv); \
+        zmsg_t *l = (zmsg_t *) zlist_first(testing_var_recv); \
+        int c = 0; \
         while (NULL != l) { \
+            ++c; \
             zmsg_destroy(&l); \
-            l = (zmsg_t *) zlist_next(testing_recv); \
+            l = (zmsg_t *) zlist_next(testing_var_recv); \
         } \
-        zlist_destroy(&testing_recv); \
+        if (0 != c) \
+            zsys_debug("%s: while performing CLEAN_RECV, %d messages were found in prepared list " \
+                    "the list was not clean in the end", __FILE__); \
+        zlist_destroy(&testing_var_recv); \
     }
 #define INIT_RECV { \
-        testing_recv = zlist_new(); \
+        testing_var_recv = zlist_new(); \
     }
 #define MSG_TO_RECV(x) { \
-        zlist_append(testing_recv, x); \
+        zlist_append(testing_var_recv, x); \
     }
 #define SET_SEND(x) { \
-        testing_send = x; \
+        testing_var_send = x; \
     }
 #define SET_UUID(x) { \
-        testing_uuid = x; \
+        testing_var_uuid = x; \
     }
 #define GET_UUID \
-    (testing_uuid)
+    (testing_var_uuid)
 #define SET_SUBJECT(x) { \
-        testing_subject = x; \
+        testing_var_subject = x; \
     }
 int testing = 0;
 TEST_VARS
+TEST_FUNCTIONS
 
 
 char verbose = 0;
@@ -124,10 +165,15 @@ static const std::map <std::pair <std::string, uint8_t>, uint32_t> times = {
 
 struct _fty_alert_actions_t {
     mlm_client_t    *client;
+    mlm_client_t    *requestreply_client;
+    zpoller_t       *requestreply_poller;
     zhash_t         *alerts_cache;
     zhash_t         *assets_cache;
     char            *name;
+    char            *requestreply_name;
     bool            integration_test;
+    uint64_t        notification_override;
+    uint64_t        requestreply_timeout;
 };
 
 typedef struct {
@@ -160,11 +206,18 @@ fty_alert_actions_new (void)
     //  Initialize class properties here
     self->client = mlm_client_new ();
     assert (self->client);
+    self->requestreply_client = mlm_client_new ();
+    assert (self->requestreply_client);
+    self->requestreply_poller = zpoller_new (mlm_client_msgpipe (self->requestreply_client), NULL);
+    assert (self->requestreply_poller);
     self->alerts_cache = zhash_new ();
     assert (self->alerts_cache);
     self->assets_cache = zhash_new ();
     assert (self->assets_cache);
     self->integration_test = false;
+    self->notification_override = 0;
+    self->name = NULL;
+    self->requestreply_name = NULL;
     return self;
 }
 
@@ -184,11 +237,20 @@ fty_alert_actions_destroy (fty_alert_actions_t **self_p)
         if (NULL != self->client) {
             mlm_client_destroy (&self->client);
         }
+        if (NULL != self->requestreply_poller) {
+            zpoller_destroy (&self->requestreply_poller);
+        }
+        if (NULL != self->requestreply_client) {
+            mlm_client_destroy (&self->requestreply_client);
+        }
         if (NULL != self->alerts_cache) {
             zhash_destroy (&self->alerts_cache);
         }
         if (NULL != self->assets_cache) {
             zhash_destroy (&self->assets_cache);
+        }
+        if (NULL != self->requestreply_name) {
+            zstr_free(&self->requestreply_name);
         }
         free (self);
         *self_p = NULL;
@@ -200,8 +262,11 @@ fty_alert_actions_destroy (fty_alert_actions_t **self_p)
 //  Calculate alert interval for asset based on severity and priority
 
 uint64_t
-get_alert_interval(s_alert_cache *alert_cache)
+get_alert_interval(s_alert_cache *alert_cache, uint64_t override_time = 0)
 {
+    if (override_time > 0) {
+        return override_time;
+    }
     zsys_debug("fty_alert_actions: get_alert_interval called");
     std::string severity = fty_proto_severity(alert_cache->alert_msg);
     uint8_t priority = (uint8_t) fty_proto_aux_number(alert_cache->related_asset, "priority", 0);
@@ -235,16 +300,22 @@ new_alert_cache_item(fty_alert_actions_t *self, fty_proto_t *msg)
         // we don't know an asset we receieved alert about, ask fty-asset about it
         zsys_debug ("fty_alert_actions: ask ASSET AGENT for ASSET_DETAIL about %s", fty_proto_name(msg));
         zuuid_t *uuid = zuuid_new ();
-        mlm_client_sendtox (self->client, FTY_ASSET_AGENT_ADDRESS, "ASSET_DETAIL", "GET",
+        mlm_client_sendtox (self->requestreply_client, FTY_ASSET_AGENT_ADDRESS, "ASSET_DETAIL", "GET",
                 zuuid_str_canonical (uuid), fty_proto_name(msg), NULL);
-        zmsg_t *reply_msg = mlm_client_recv (self->client);
-        if (reply_msg) {
+        void *which = zpoller_wait (self->requestreply_poller, self->requestreply_timeout);
+        if (which == NULL) {
+            zsys_warning("fty_alert_actions: no response from ASSET AGENT, ignoring this alert.");
+            fty_proto_destroy(&msg);
+            free(c);
+            c = NULL;
+        } else {
+            zmsg_t *reply_msg = mlm_client_recv (self->requestreply_client);
             char *rcv_uuid = zmsg_popstr (reply_msg);
             if (0 == strcmp (rcv_uuid, zuuid_str_canonical (uuid)) && fty_proto_is (reply_msg)) {
                 zsys_debug("fty_alert_actions: receieved alert for unknown asset, asked for it and was successful.");
                 fty_proto_t *reply_proto_msg = fty_proto_decode (&reply_msg);
                 s_handle_stream_deliver_asset (self, &reply_proto_msg, mlm_client_subject (self->client));
-                c->related_asset = reply_proto_msg;
+                c->related_asset = (fty_proto_t *) zhash_lookup(self->assets_cache, fty_proto_name(msg));
             }
             else {
                 zsys_warning("fty_alert_actions: receieved alert for unknown asset, ignoring.");
@@ -254,13 +325,6 @@ new_alert_cache_item(fty_alert_actions_t *self, fty_proto_t *msg)
                 c = NULL;
             }
             zstr_free(&rcv_uuid);
-        }
-        else {
-            zsys_warning("fty_alert_actions: no response from ASSET AGENT, ignoring this alert.");
-            zmsg_destroy(&reply_msg);
-            fty_proto_destroy(&msg);
-            free(c);
-            c = NULL;
         }
         zuuid_destroy (&uuid);
     } else {
@@ -288,45 +352,51 @@ delete_alert_cache_item(void *c)
 void
 send_email(fty_alert_actions_t *self, s_alert_cache *alert_item, char action_email)
 {
-    zsys_debug("fty_alert_actions: sending SENDMAIL_ALERT for %s", fty_proto_name(alert_item->alert_msg));
+    zsys_debug("fty_alert_actions: sending SENDMAIL_ALERT/SENDSMS_ALERT for %s", fty_proto_name(alert_item->alert_msg));
     fty_proto_t *alert_dup = fty_proto_dup(alert_item->alert_msg);
     zmsg_t *email_msg = fty_proto_encode(&alert_dup);
     zuuid_t *uuid = zuuid_new ();
+    char *subject = NULL;
     const char *sname = fty_proto_ext_string(alert_item->related_asset, "name", "");
     if (EMAIL_ACTION_VALUE == action_email) {
         const char *contact_email = fty_proto_ext_string(alert_item->related_asset, "contact_email", "");
         zmsg_pushstr (email_msg, contact_email);
+        subject = (char *) "SENDMAIL_ALERT";
     } else {
         const char *contact_sms = fty_proto_ext_string(alert_item->related_asset, "contact_sms", "");
         zmsg_pushstr (email_msg, contact_sms);
+        subject = (char *) "SENDSMS_ALERT";
     }
     const char *priority = fty_proto_aux_string(alert_item->related_asset, "priority", "");
     zmsg_pushstr (email_msg, sname);
     zmsg_pushstr (email_msg, priority);
     zmsg_pushstr (email_msg, zuuid_str_canonical (uuid));
     const char *address = (self->integration_test) ? FTY_EMAIL_AGENT_ADDRESS_TEST : FTY_EMAIL_AGENT_ADDRESS;
-    int rv = mlm_client_sendto (self->client, address, "SENDMAIL_ALERT", NULL, 5000, &email_msg);
+    int rv = mlm_client_sendto (self->requestreply_client, address, subject, NULL, 5000, &email_msg);
     if ( rv != 0) {
-        zsys_error ("fty_alert_actions: cannot send SENDMAIL_ALERT message");
+        zsys_error ("fty_alert_actions: cannot send %s message", subject);
         zuuid_destroy (&uuid);
         zmsg_destroy (&email_msg);
         return;
     }
-    zmsg_t *reply_msg = mlm_client_recv (self->client);
-    if (reply_msg) {
+    void *which = zpoller_wait (self->requestreply_poller, self->requestreply_timeout);
+    if (which == NULL) {
+        zsys_error ("fty_alert_actions: received no reply on %s message", subject);
+    } else {
+        zmsg_t *reply_msg = mlm_client_recv (self->requestreply_client);
         char *rcv_uuid = zmsg_popstr (reply_msg);
         if (0 == strcmp (rcv_uuid, zuuid_str_canonical (uuid))) {
             char *cmd = zmsg_popstr (reply_msg);
             if (0 == strcmp(cmd, "OK")) {
-                zsys_debug ("fty_alert_actions: SENDMAIL_ALERT successful");
+                zsys_debug ("fty_alert_actions: %s successful", subject);
             } else {
                 char *cause = zmsg_popstr (reply_msg);
-                zsys_error ("fty_alert_actions: SENDMAIL_ALERT failed due to %s", cause);
+                zsys_error ("fty_alert_actions: %s failed due to %s", subject, cause);
                 zstr_free(&cause);
             }
             zstr_free(&cmd);
         } else {
-            zsys_error ("fty_alert_actions: received invalid reply on SENDMAIL_ALERT message");
+            zsys_error ("fty_alert_actions: received invalid reply on %s message", subject);
         }
         zstr_free(&rcv_uuid);
         zmsg_destroy (&reply_msg);
@@ -345,7 +415,7 @@ send_gpo_action(fty_alert_actions_t *self, char *gpo_iname, char *gpo_state)
     zuuid_t *zuuid = zuuid_new ();
     const char *address = (self->integration_test) ? FTY_SENSOR_GPIO_AGENT_ADDRESS_TEST : FTY_SENSOR_GPIO_AGENT_ADDRESS;
     int rv = mlm_client_sendtox
-                (self->client,
+                (self->requestreply_client,
                  address,
                  "GPO_INTERACTION",
                  zuuid_str_canonical (zuuid),
@@ -356,8 +426,11 @@ send_gpo_action(fty_alert_actions_t *self, char *gpo_iname, char *gpo_state)
         zsys_error ("fty_alert_actions: cannot send GPO_INTERACTION message");
         return;
     }
-    zmsg_t *reply_msg = mlm_client_recv (self->client);
-    if (reply_msg) {
+    void *which = zpoller_wait (self->requestreply_poller, self->requestreply_timeout);
+    if (which == NULL) {
+        zsys_error ("fty_alert_actions: received no reply on GPO_INTERACTION message");
+    } else {
+        zmsg_t *reply_msg = mlm_client_recv (self->requestreply_client);
         char *zuuid_str = zmsg_popstr (reply_msg);
         if (streq (zuuid_str, zuuid_str_canonical (zuuid))) {
             char *cmd = zmsg_popstr (reply_msg);
@@ -589,7 +662,7 @@ check_alerts_and_send_if_needed(fty_alert_actions_t *self)
     s_alert_cache *it = (s_alert_cache *) zhash_first(self->alerts_cache);
     uint64_t now = zclock_mono ();
     while (NULL != it) {
-        uint64_t notification_delay = get_alert_interval(it);
+        uint64_t notification_delay = get_alert_interval(it, self->notification_override);
         if (0 != notification_delay && (it->last_notification + notification_delay < now)) {
             action_alert_repeat(self, it);
         }
@@ -611,7 +684,8 @@ s_handle_stream_deliver_alert (fty_alert_actions_t *self, fty_proto_t **alert_p,
     assert (subject);
     fty_proto_t *alert = *alert_p;
     if (!alert || fty_proto_id (alert) != FTY_PROTO_ALERT) {
-        fty_proto_destroy (&alert);
+        if (alert)
+            fty_proto_destroy (&alert);
         zsys_warning ("fty_alert_actions: Message not FTY_PROTO_ALERT.");
         return;
     }
@@ -662,6 +736,11 @@ s_handle_stream_deliver_alert (fty_alert_actions_t *self, fty_proto_t **alert_p,
                 changed = 1;
             }
             zsys_debug ("changed = %d", changed);
+            if (1 == changed) {
+                // simple workaround to handle alerts for assets changed during alert being active
+                zsys_debug("fty_alert_actions: known alarm resolved as updated, resolving previous alert");
+                action_resolve(self, search);
+            }
             fty_proto_destroy(&search->alert_msg);
             search->alert_msg = alert;
             if (1 == changed) {
@@ -700,7 +779,8 @@ s_handle_stream_deliver_asset (fty_alert_actions_t *self, fty_proto_t **asset_p,
     assert (subject);
     fty_proto_t *asset = *asset_p;
     if (!asset || fty_proto_id (asset) != FTY_PROTO_ASSET) {
-        fty_proto_destroy (&asset);
+        if (asset)
+            fty_proto_destroy (&asset);
         zsys_warning ("fty_alert_actions: Message not FTY_PROTO_ASSET.");
         return;
     }
@@ -713,7 +793,7 @@ s_handle_stream_deliver_asset (fty_alert_actions_t *self, fty_proto_t **asset_p,
         if (NULL != item) {
             s_alert_cache *it = (s_alert_cache *) zhash_first(self->alerts_cache);
             if (NULL != it)
-                zsys_debug("fty_alert_actions: %d had active alarms, resolving them", assetname);
+                zsys_debug("fty_alert_actions: %s may had active alarms, resolving them", assetname);
             while (NULL != it) {
                 if (it->related_asset == item) {
                     // delete all alerts related to deleted asset
@@ -728,8 +808,53 @@ s_handle_stream_deliver_asset (fty_alert_actions_t *self, fty_proto_t **asset_p,
     }
     else if (streq (operation, "update")) {
         zsys_debug("fty_alert_actions: received update for asset %s", assetname);
-        zhash_update(self->assets_cache, assetname, asset);
-        zhash_freefn(self->assets_cache, assetname, fty_proto_destroy_wrapper);
+        fty_proto_t *known = (fty_proto_t *) zhash_lookup(self->assets_cache, assetname);
+        if (NULL != known) {
+            char changed = 0;
+            if (!streq(fty_proto_ext_string(known, "contact_email", ""),
+                        fty_proto_ext_string(asset, "contact_email", "")) ||
+                    !streq(fty_proto_ext_string(known, "contact_phone", ""),
+                        fty_proto_ext_string(asset, "contact_phone", ""))) {
+                changed = 1;
+            }
+            zsys_debug ("changed = %d", changed);
+            if (1 == changed) {
+                // simple workaround to handle alerts for assets changed during alert being active
+                zsys_debug("fty_alert_actions: known asset was updated, resolving previous alert");
+                s_alert_cache *it = (s_alert_cache *) zhash_first(self->alerts_cache);
+                if (NULL != it)
+                    zsys_debug("fty_alert_actions: resolving all active alarms for %s", assetname);
+                while (NULL != it) {
+                    if (it->related_asset == known) {
+                        // just resolve, will be activated again
+                        action_resolve(self, it);
+                    }
+                    it = (s_alert_cache *) zhash_next(self->alerts_cache);
+                }
+            }
+            zhash_t *tmp_ext = fty_proto_get_ext(asset);
+            zhash_t *tmp_aux = fty_proto_get_aux(asset);
+            fty_proto_set_ext(known, &tmp_ext);
+            fty_proto_set_aux(known, &tmp_aux);
+            assetname = fty_proto_name (known);
+            fty_proto_destroy(asset_p);
+            if (1 == changed) {
+                zsys_debug("fty_alert_actions: known asset was updated, sending notifications");
+                s_alert_cache *it = (s_alert_cache *) zhash_first(self->alerts_cache);
+                if (NULL != it)
+                    zsys_debug("fty_alert_actions: checking for alarms assigned to %s", assetname);
+                while (NULL != it) {
+                    if (it->related_asset == known) {
+                        // just resolve, will be activated again
+                        action_alert(self, it);
+                    }
+                    it = (s_alert_cache *) zhash_next(self->alerts_cache);
+                }
+            }
+        } else {
+            zhash_insert(self->assets_cache, assetname, asset);
+            zhash_freefn(self->assets_cache, assetname, fty_proto_destroy_wrapper);
+        }
     }
     else {
         // 'create' is skipped because each is followed by an 'update'
@@ -768,7 +893,7 @@ s_handle_stream_deliver (fty_alert_actions_t *self, zmsg_t** msg_p, const char *
 //  Handle incoming alerts through pipe
 
 static int
-s_handle_pipe_deliver (fty_alert_actions_t *self, zmsg_t** msg_p)
+s_handle_pipe_deliver (fty_alert_actions_t *self, zmsg_t** msg_p, uint64_t &timeout)
 {
     zsys_debug("fty_alert_actions: s_handle_pipe_deliver called");
     zmsg_t *msg = *msg_p;
@@ -780,22 +905,22 @@ s_handle_pipe_deliver (fty_alert_actions_t *self, zmsg_t** msg_p)
         zmsg_destroy (&msg);
         return -1;
     }
-    else
-    if (streq (cmd, "VERBOSE")) {
+    else if (streq (cmd, "VERBOSE")) {
         zsys_debug ("fty_alert_actions: VERBOSE received");
         verbose = 1;
     }
-    else
-    if (streq (cmd, "CONNECT")) {
+    else if (streq (cmd, "CONNECT")) {
         zsys_debug ("fty_alert_actions: CONNECT received");
         char* endpoint = zmsg_popstr (msg);
         int rv = mlm_client_connect (self->client, endpoint, 1000, self->name);
         if (rv == -1)
             zsys_error ("fty_alert_actions: can't connect to malamute endpoint '%s'", endpoint);
+        rv = mlm_client_connect (self->requestreply_client, endpoint, 1000, self->requestreply_name);
+        if (rv == -1)
+            zsys_error ("fty_alert_actions: can't connect requestreply to malamute endpoint '%s'", endpoint);
         zstr_free (&endpoint);
     }
-    else
-    if (streq (cmd, "CONSUMER")) {
+    else if (streq (cmd, "CONSUMER")) {
         zsys_debug ("fty_alert_actions: CONSUMER received");
         char* stream = zmsg_popstr (msg);
         self->integration_test = streq (stream, TEST_ALERTS) || streq (stream, TEST_ASSETS);
@@ -814,6 +939,18 @@ s_handle_pipe_deliver (fty_alert_actions_t *self, zmsg_t** msg_p)
             zsys_error ("fty_alert_actions: can't send REPUBLISH message");
         }
     }
+    else if (streq(cmd, "TESTTIMEOUT")) {
+        zsys_debug ("fty_alert_actions: setting test timeout to received value");
+        char *rcvd = zmsg_popstr (msg);
+        sscanf(rcvd, "%" SCNu64, &timeout);
+        zstr_free (&rcvd);
+    }
+    else if (streq(cmd, "TESTCHECKINTERVAL")) {
+        zsys_debug ("fty_alert_actions: setting test interval for checks");
+        char *rcvd = zmsg_popstr (msg);
+        sscanf(rcvd, "%" SCNu64, &(self->notification_override));
+        zstr_free (&rcvd);
+    }
     zstr_free (&cmd);
     zmsg_destroy (&msg);
     return 0;
@@ -830,6 +967,8 @@ fty_alert_actions (zsock_t *pipe, void* args)
     fty_alert_actions_t *self = fty_alert_actions_new ();
     assert(self);
     self->name = (char*) args;
+    self->requestreply_name = zsys_sprintf("%s#mb", self->name);
+    self->requestreply_timeout = 1000; // hopefully 1ms will be long enough to get input
     zpoller_t *poller = zpoller_new (pipe, mlm_client_msgpipe (self->client), NULL);
     assert (poller);
     uint64_t timeout = 1000 * 60 * 1; // check every minute
@@ -852,7 +991,7 @@ fty_alert_actions (zsock_t *pipe, void* args)
         // pipe messages
         if (which == pipe) {
             msg = zmsg_recv (pipe);
-            if (0 == s_handle_pipe_deliver(self, &msg)) {
+            if (0 == s_handle_pipe_deliver(self, &msg, timeout)) {
                 continue;
             } else {
                 break;
@@ -869,6 +1008,7 @@ fty_alert_actions (zsock_t *pipe, void* args)
                 mlm_client_address (self->client),
                 mlm_client_sender (self->client),
                 mlm_client_subject (self->client));
+        zmsg_destroy(&msg);
     }
     zpoller_destroy (&poller);
     fty_alert_actions_destroy (&self);
@@ -960,10 +1100,10 @@ fty_alert_actions_test (bool verbose)
     assert (self);
     fty_proto_t *asset = fty_proto_new(FTY_PROTO_ASSET);
     assert (asset);
-    zhash_insert(self->assets_cache, "myasset-1", asset);
+    zhash_insert(self->assets_cache, "myasset-3", asset);
     fty_proto_t *msg = fty_proto_new(FTY_PROTO_ALERT);
     assert (msg);
-    fty_proto_set_name(msg, "myasset-1");
+    fty_proto_set_name(msg, "myasset-3");
 
     s_alert_cache *cache = new_alert_cache_item(self, msg);
     assert(cache);
@@ -988,7 +1128,7 @@ fty_alert_actions_test (bool verbose)
     assert (self);
     fty_proto_t *msg = fty_proto_new(FTY_PROTO_ALERT);
     assert (msg);
-    fty_proto_set_name(msg, "myasset-2");
+    fty_proto_set_name(msg, "myasset-4");
 
     s_alert_cache *cache = new_alert_cache_item(self, msg);
     assert(cache);
@@ -1416,10 +1556,12 @@ fty_alert_actions_test (bool verbose)
         zmsg_t *reply = zmsg_new ();
         zmsg_addstr (reply, zuuid_str);
         zmsg_addstr (reply, "OK");
+        zclock_sleep (1000);
         mlm_client_sendto (email_client, FTY_ALERT_ACTIONS_TEST, "SENDMAIL_ALERT", NULL, 1000, &reply);
 
         zstr_free (&zuuid_str);
     }
+    zclock_sleep (1000);
     //test 11: two alerts in quick succession, only one e-mail
     {
         zsys_debug("fty_alert_actions: test 11");
@@ -1640,29 +1782,20 @@ fty_alert_actions_test (bool verbose)
         assert ( rv != -1 );
         zlist_destroy (&actions);
 
-        //FIXME: expected behaviour is to send an e-mail on first alert after contact update
-        zpoller_t *poller = zpoller_new (mlm_client_msgpipe (email_client), NULL);
-        void *which = zpoller_wait (poller, 1000);
-        assert ( which == NULL );
-        if ( verbose ) {
-            zsys_debug ("No email was sent: SUCCESS");
-        }
-        zpoller_destroy (&poller);
-
         //      6. Email SHOULD be generated
-        //msg = mlm_client_recv (email_client);
-        //assert (msg);
-        //assert (streq (mlm_client_subject (email_client), "SENDMAIL_ALERT"));
-        //zuuid_str = zmsg_popstr (msg);
-        //zmsg_destroy (&msg);
+        msg = mlm_client_recv (email_client);
+        assert (msg);
+        assert (streq (mlm_client_subject (email_client), "SENDMAIL_ALERT"));
+        zuuid_str = zmsg_popstr (msg);
+        zmsg_destroy (&msg);
 
         //       7. send the reply to unblock the actor
-        //reply = zmsg_new ();
-        //zmsg_addstr (reply, zuuid_str);
-        //zmsg_addstr (reply, "OK");
-        //mlm_client_sendto (email_client, FTY_ALERT_ACTIONS_TEST, "SENDMAIL_ALERT", NULL, 1000, &reply);
+        reply = zmsg_new ();
+        zmsg_addstr (reply, zuuid_str);
+        zmsg_addstr (reply, "OK");
+        mlm_client_sendto (email_client, FTY_ALERT_ACTIONS_TEST, "SENDMAIL_ALERT", NULL, 1000, &reply);
 
-        //zstr_free (&zuuid_str);
+        zstr_free (&zuuid_str);
     }
     //test 14, on ACK-SILENCE we send only one e-mail and then stop
     {
@@ -1752,8 +1885,10 @@ fty_alert_actions_test (bool verbose)
         zstr_free (&zuuid_str);
 
         // wait for 5 minutes
-        zsys_debug ("sleeping for 5 minutes...");
-        zclock_sleep (5*60*1000);
+        zstr_sendx (alert_actions, "TESTTIMEOUT", "1000", NULL);
+        zstr_sendx (alert_actions, "TESTCHECKINTERVAL", "20000", NULL);
+        zsys_debug ("sleeping for 20 seconds...");
+        zclock_sleep (20*1000);
         //      7. send an alert again
         actions = zlist_new ();
         zlist_autofree (actions);
@@ -1847,14 +1982,17 @@ fty_alert_actions_test (bool verbose)
         zmsg_t *reply = zmsg_new ();
         zmsg_addstr (reply, zuuid_str);
         zmsg_addstr (reply, "OK");
+        zclock_sleep (1000);
         mlm_client_sendto (email_client, FTY_ALERT_ACTIONS_TEST, "SENDMAIL_ALERT", NULL, 1000, &reply);
 
         zstr_free (&zuuid_str);
+        zclock_sleep (1000);
 
-        //      3. check that we generate SENDMAIL_ALERT message with empty contact
+        //      3. check that we generate SENDSMS_ALERT message with empty contact
         email = mlm_client_recv (email_client);
         assert (email);
-        assert (streq (mlm_client_subject (email_client), "SENDMAIL_ALERT"));
+        zsys_debug(mlm_client_subject (email_client));
+        assert (streq (mlm_client_subject (email_client), "SENDSMS_ALERT"));
         zuuid_str = zmsg_popstr (email);
         str = zmsg_popstr (email);
         assert (streq (str, "1"));
@@ -1881,10 +2019,10 @@ fty_alert_actions_test (bool verbose)
         assert (msg);
         rv = mlm_client_send (asset_producer, "Asset message8", &msg);
         assert ( rv != -1 );
+
         zhash_destroy (&aux);
         zhash_destroy (&ext);
         zclock_sleep (1000);
-
         //      6. send alert message again second
         actions = zlist_new ();
         zlist_autofree (actions);
@@ -1905,30 +2043,43 @@ fty_alert_actions_test (bool verbose)
         assert ( rv != -1 );
         zlist_destroy (&actions);
 
-        //FIXME: expected behaviour is to send an e-mail on first alert after contact update
-        zpoller_t *poller = zpoller_new (mlm_client_msgpipe (email_client), NULL);
-        void *which = zpoller_wait (poller, 1000);
-        assert ( which == NULL );
-        if ( verbose ) {
-            zsys_debug ("No email was sent: SUCCESS");
-        }
-        zpoller_destroy (&poller);
         //      6. Email SHOULD be generated
-        //msg = mlm_client_recv (email_client);
-        //assert (msg);
-        //if ( verbose )
-        //    zsys_debug ("Email was sent: SUCCESS");
-        //assert (streq (mlm_client_subject (email_client), "SENDMAIL_ALERT"));
-        //char *zuuid_str = zmsg_popstr (msg);
-        //zmsg_destroy (&msg);
+        msg = mlm_client_recv (email_client);
+        assert (msg);
+        if ( verbose )
+            zsys_debug ("Email was sent: SUCCESS");
+        assert (streq (mlm_client_subject (email_client), "SENDMAIL_ALERT"));
+        zuuid_str = zmsg_popstr (msg);
+        zmsg_destroy (&msg);
+        zclock_sleep (1000);
 
         //       7. send the reply to unblock the actor
-        //zmsg_t *reply = zmsg_new ();
-        //zmsg_addstr (reply, zuuid_str);
-        //zmsg_addstr (reply, "OK");
-        //mlm_client_sendto (email_client, FTY_ALERT_ACTIONS_TEST, "SENDMAIL_ALERT", NULL, 1000, &reply);
+        reply = zmsg_new ();
+        zmsg_addstr (reply, zuuid_str);
+        zmsg_addstr (reply, "OK");
+        mlm_client_sendto (email_client, FTY_ALERT_ACTIONS_TEST, "SENDMAIL_ALERT", NULL, 1000, &reply);
 
-        //zstr_free (&zuuid_str);
+        zstr_free (&zuuid_str);
+        zclock_sleep (1000);
+
+        //      6. SMS SHOULD be generated
+        msg = mlm_client_recv (email_client);
+        assert (msg);
+        if ( verbose )
+            zsys_debug ("SMS was sent: SUCCESS");
+        assert (streq (mlm_client_subject (email_client), "SENDSMS_ALERT"));
+        zuuid_str = zmsg_popstr (msg);
+        zmsg_destroy (&msg);
+        zclock_sleep (1000);
+
+        //       7. send the reply to unblock the actor
+        reply = zmsg_new ();
+        zmsg_addstr (reply, zuuid_str);
+        zmsg_addstr (reply, "OK");
+        mlm_client_sendto (email_client, FTY_ALERT_ACTIONS_TEST, "SENDSMS_ALERT", NULL, 1000, &reply);
+        zclock_sleep (1000);
+
+        zstr_free (&zuuid_str);
 
         //      8. send alert message again third time
         actions = zlist_new ();
@@ -1951,8 +2102,9 @@ fty_alert_actions_test (bool verbose)
         zlist_destroy (&actions);
 
         //      9. Email SHOULD NOT be generated
-        poller = zpoller_new (mlm_client_msgpipe (email_client), NULL);
-        which = zpoller_wait (poller, 1000);
+        zclock_sleep (1000);
+        zpoller_t *poller = zpoller_new (mlm_client_msgpipe (email_client), NULL);
+        void *which = zpoller_wait (poller, 1000);
         assert ( which == NULL );
         if ( verbose )
             zsys_debug ("Email was NOT sent: SUCCESS");


### PR DESCRIPTION
Solution: fixed MB reply out of order issue, fixed unit tests
The reason for MB replies was that mlm_client_recv funciton is used to receive MB replies, but this function actually receives anything that was sent to agent, such as other MB messages or even STREAM messages.