### PR TITLE
Problem: Redundant severity / actions for GPI

### DIFF
--- a/src/rule_templates/door-contact.state-change@__device_sensorgpio__.rule
+++ b/src/rule_templates/door-contact.state-change@__device_sensorgpio__.rule
@@ -8,8 +8,7 @@
     "models"	    : ["DCS001"],
     "types" 	    : ["sensorgpio", "rackcontroller"],
     "results"       :  {
-        "high_critical"  : { "action" : [{ "action": "EMAIL" },{ "action": "SMS" }] },
-        "high_warning"   : { "action" : [{ "action": "EMAIL" }] }
+        "high___severity__"   : { "action" : [{ "action": "EMAIL" }] }
     },
     "evaluation"    : "
         function main(current_state)

--- a/src/rule_templates/pir-motion-detector.state-change@__device_sensorgpio__.rule
+++ b/src/rule_templates/pir-motion-detector.state-change@__device_sensorgpio__.rule
@@ -8,8 +8,7 @@
     "models"	    : ["XCELW"],
     "types" 	    : ["sensorgpio", "rackcontroller"],
     "results"       :  {
-        "high_critical"  : { "action" : [{ "action": "EMAIL" },{ "action": "SMS" }] },
-        "high_warning"   : { "action" : [{ "action": "EMAIL" }] }
+        "high___severity__"   : { "action" : [{ "action": "EMAIL" }] }
     },
     "evaluation"    : "
         function main(current_state)

--- a/src/rule_templates/smoke-detector.state-change@__device_sensorgpio__.rule
+++ b/src/rule_templates/smoke-detector.state-change@__device_sensorgpio__.rule
@@ -8,8 +8,7 @@
     "models"	    : ["M12"],
     "types" 	    : ["sensorgpio", "rackcontroller"],
     "results"       :  {
-        "high_critical"  : { "action" : [{ "action": "EMAIL" },{ "action": "SMS" }] },
-        "high_warning"   : { "action" : [{ "action": "EMAIL" }] }
+        "high___severity__"   : { "action" : [{ "action": "EMAIL" }] }
     },
     "evaluation"    : "
         function main(current_state)

--- a/src/rule_templates/vibration-sensor.state-change@__device_sensorgpio__.rule
+++ b/src/rule_templates/vibration-sensor.state-change@__device_sensorgpio__.rule
@@ -8,8 +8,7 @@
     "models"	    : ["VIB001"],
     "types" 	    : ["sensorgpio", "rackcontroller"],
     "results"       :  {
-        "high_critical"  : { "action" : [{ "action": "EMAIL" },{ "action": "SMS" }] },
-        "high_warning"   : { "action" : [{ "action": "EMAIL" }] }
+        "high___severity__"   : { "action" : [{ "action": "EMAIL" }] }
     },
     "evaluation"    : "
         function main(current_state)

--- a/src/rule_templates/water-leak-detector.state-change@__device_sensorgpio__.rule
+++ b/src/rule_templates/water-leak-detector.state-change@__device_sensorgpio__.rule
@@ -8,8 +8,7 @@
     "models"	    : ["WLD012"],
     "types" 	    : ["sensorgpio", "rackcontroller"],
     "results"       :  {
-        "high_critical"  : { "action" : [{ "action": "EMAIL" },{ "action": "SMS" }] },
-        "high_warning"   : { "action" : [{ "action": "EMAIL" }] }
+        "high___severity__"   : { "action" : [{ "action": "EMAIL" }] }
     },
     "evaluation"    : "
         function main(current_state)

--- a/src/templateruleconfigurator.cc
+++ b/src/templateruleconfigurator.cc
@@ -28,6 +28,7 @@
 
 #include "fty_alert_engine_classes.h"
 
+#include <algorithm>
 #include <cxxtools/directory.h>
 #include "templateruleconfigurator.h"
 #include "autoconfig.h"
@@ -47,8 +48,10 @@ TemplateRuleConfigurator::configure (const std::string& name, const AutoConfigur
                     if (i.first == "port")
                         port = "GPI" + i.second;
                     else
-                    if (i.first == "alarm_severity")
+                    if (i.first == "alarm_severity") {
                         severity = i.second;
+                        std::transform(severity.begin(), severity.end(), severity.begin(), ::tolower);
+                    }
                     else
                     if (i.first == "normal_state")
                         normal_state = i.second;


### PR DESCRIPTION
Solution: Adapt template and results

Conversely to other flexible managed template rules (such as STS/ATS), GPI have
an "alarm severity" configured at commissioning time, which has to be used when
instanciating rules.

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>