### PR TITLE
Jiri's Fixes from master for 1.3

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,9 @@
 /*
+ *  Note: This Jenkinsfile is amended for longer test timeouts and 'rm -rf'
+ *        instead of deleteDir() due to non-ASCII filenames in tests
+ */
+
+/*
     fty-alert-engine - 42ity service evaluating rules written in Lua and producing alerts
 
     Copyright (C) 2014 - 2017 Eaton

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -184,15 +184,8 @@ pipeline {
                 }
             }
         }
-        // Self-test stages below should be run sequentially, as decreed by
-        // project authors for the time being (e.g. port conflicts, etc.)
-        // You can uncomment the closures below experimentally, but proper
-        // fix belongs in the project.xml (e.g. use separate agents if your
-        // infrastructure is set up to only schedule one build on the agent
-        // at a time) and better yet - in the project sources, to not have
-        // the conflicts at all.
-//        stage ('check') {
-//            parallel {
+        stage ('check') {
+            parallel {
                 stage ('check with DRAFT') {
                     when { expression { return ( params.DO_BUILD_WITH_DRAFT_API && params.DO_TEST_CHECK ) } }
                     steps {
@@ -376,9 +369,8 @@ pipeline {
                       }
                     }
                 }
-        // Sequential block of self-tests end here
-//            }
-//        }
+            }
+        }
         stage ('deploy if appropriate') {
             steps {
                 script {

--- a/include/autoconfig.h
+++ b/include/autoconfig.h
@@ -37,6 +37,7 @@ struct AutoConfigurationInfo
     std::string type;
     std::string subtype;
     std::string operation;
+    std::string update_ts;
     bool configured = false;
     uint64_t date = 0;
     std::map <std::string, std::string> attributes;

--- a/project.xml
+++ b/project.xml
@@ -17,6 +17,8 @@
         <option name = "test_cppcheck" value = "1" />
         <option name = "build_docs" value = "1" />
         <option name = "check_sequential" value = "0" />
+        <!-- Note: Jenkinsfile is amended for longer test timeouts and 'rm -rf'
+             instead of deleteDir() due to non-ASCII filenames in tests -->
     </target>
 
     <include filename = "license.xml" />

--- a/project.xml
+++ b/project.xml
@@ -16,7 +16,7 @@
         <option name = "triggers_pollSCM" value = "H/2 * * * *" />
         <option name = "test_cppcheck" value = "1" />
         <option name = "build_docs" value = "1" />
-        <option name = "check_sequential" value = "1" />
+        <option name = "check_sequential" value = "0" />
     </target>
 
     <include filename = "license.xml" />

--- a/src/autoconfig.cc
+++ b/src/autoconfig.cc
@@ -293,6 +293,13 @@ Autoconfig::onSend (fty_proto_t **message)
     info.type.assign (fty_proto_aux_string (*message, "type", ""));
     info.subtype.assign (fty_proto_aux_string (*message, "subtype", ""));
     info.operation.assign (fty_proto_operation (*message));
+    info.update_ts.assign (fty_proto_ext_string(*message, "update_ts", ""));
+
+    if (_configurableDevices.find(device_name)!=_configurableDevices.end() &&
+            0 != strcmp(fty_proto_ext_string(*message, "update_ts", ""),_configurableDevices[device_name].update_ts.c_str())) {
+        zsys_debug("Changed asset, updating");
+        info.configured = false;
+    }
 
     if (streq (fty_proto_aux_string (*message, "type", ""), "datacenter") ||
         streq (fty_proto_aux_string (*message, "type", ""), "room") ||
@@ -300,7 +307,7 @@ Autoconfig::onSend (fty_proto_t **message)
         streq (fty_proto_aux_string (*message, "type", ""), "rack"))
     {
         if (info.operation != "delete") {
-            _containers.emplace (device_name, fty_proto_ext_string (*message, "name", ""));
+            _containers[device_name] = fty_proto_ext_string (*message, "name", "");
         } else {
             try {
                 _containers.erase(device_name);
@@ -317,7 +324,7 @@ Autoconfig::onSend (fty_proto_t **message)
             device_name.c_str (), info.type.c_str (), info.subtype.c_str (), info.operation.c_str ());
     info.attributes = utils::zhash_to_map(fty_proto_ext (*message));
     if (info.operation != "delete") {
-        _configurableDevices.emplace (std::make_pair (device_name, info));
+        _configurableDevices[device_name] = info;
     } else {
         try {
             _configurableDevices.erase(device_name);


### PR DESCRIPTION
In particular, we need the last commit
67fdaa9864e3 ("Fixed alerts not refreshed on asset update")
A follow-up fix for fty-alert-flexible will be pushed later.