### PR TITLE
Problem: Agent fty-alert-engine sometines crashes.

### DIFF
--- a/src/fty_alert_actions.cc
+++ b/src/fty_alert_actions.cc
@@ -957,11 +957,13 @@ fty_alert_actions(zsock_t *pipe, void* args) {
             continue;
         }
         // all other messages should be ignored
-        zsys_debug("fty_alert_actions: received message through '%s' from '%s' with subject '%s' that is ignored",
-                mlm_client_address(self->client),
-                mlm_client_sender(self->client),
-                mlm_client_subject(self->client));
-        zmsg_destroy(&msg);
+        else {
+            zsys_debug("fty_alert_actions: received message through '%s' from '%s' with subject '%s' that is ignored",
+                    mlm_client_address(self->client),
+                    mlm_client_sender(self->client),
+                    mlm_client_subject(self->client));
+            zmsg_destroy(&msg);
+        }
     }
     zpoller_destroy(&poller);
     fty_alert_actions_destroy(&self);


### PR DESCRIPTION
Solution: Remove the double free.

Signed-off-by: Jana Rapava <janarapava@eaton.com>