### PR TITLE
Discard metrics received too late

### DIFF
--- a/src/fty_alert_engine_server.cc
+++ b/src/fty_alert_engine_server.cc
@@ -34,6 +34,7 @@
 #include <math.h>
 #include <functional>
 #include <algorithm>
+#include <unordered_map>
 
 int agent_alert_verbose = 0;
 
@@ -478,6 +479,46 @@ fty_alert_engine_server (zsock_t *pipe, void* args)
             continue;
         }
 
+        // Drain the queue of pending METRICS stream messages before
+        // doing actual work
+
+        // METRICS messages received in this round
+        std::unordered_map<std::string, fty_proto_t*> stream_messages;
+        // Mailbox message received (if any)
+        zmsg_t *zmessage = NULL;
+        std::string subject;
+        while (which == mlm_client_msgpipe(client)) {
+            zmsg_t *zmsg = mlm_client_recv(client);
+            if (!is_fty_proto(zmsg)) {
+                zmessage = zmsg;
+                subject = mlm_client_subject(client);
+                break;
+            }
+            std::string topic = mlm_client_subject(client);
+            fty_proto_t *bmessage = fty_proto_decode(&zmsg);
+            if (!bmessage) {
+                zsys_error ("%s: can't decode message with topic %s, ignoring", name, topic.c_str());
+                break;
+            }
+            if (fty_proto_id(bmessage) != FTY_PROTO_METRIC) {
+                zsys_error ("%s: unsupported proto id %d for topic %s, ignoring", name, fty_proto_id(bmessage), topic.c_str());
+                fty_proto_destroy(&bmessage);
+                break;
+            }
+            auto it = stream_messages.find(topic);
+            if (it == stream_messages.end()) {
+                stream_messages.emplace(topic, bmessage);
+            } else {
+                // Discard the old METRICS update, we did not manage to process
+                // it in time.
+                zsys_warning("%s: Metrics update '%s' processed too late, discarding", name, topic.c_str());
+                fty_proto_destroy(&it->second);
+                it->second = bmessage;
+            }
+            // Check if further messages are pending
+            which = zpoller_wait(poller, 0);
+        }
+
         if (which == pipe) {
             zmsg_t *msg = zmsg_recv (pipe);
             char *cmd = zmsg_popstr (msg);
@@ -546,66 +587,57 @@ fty_alert_engine_server (zsock_t *pipe, void* args)
         // and doesn't do anything if there is no messages
         // TODO: probably alert also should be send every XXX seconds,
         // even if no measurements were recieved
-        zmsg_t *zmessage = mlm_client_recv (client);
-        if ( zmessage == NULL ) {
-            continue;
-        }
-        std::string topic = mlm_client_subject(client);
         // There are two possible inputs and they come in different ways
         // from the stream  -> metrics
         // from the mailbox -> rules
         //                  -> request for rule list
         // but even so we try to decide according what we got, not from where
-        if ( is_fty_proto(zmessage) ) {
-            fty_proto_t *bmessage = fty_proto_decode(&zmessage);
-            if( ! bmessage ) {
-                zsys_error ("%s: can't decode message with topic %s, ignoring", name, topic.c_str());
+
+        // process accumulated stream messages
+        for (auto element : stream_messages) {
+            std::string topic = element.first;
+            fty_proto_t *bmessage = element.second;
+            // process as metric message
+            const char *type = fty_proto_type(bmessage);
+            const char * name = fty_proto_name (bmessage);
+            const char *value = fty_proto_value(bmessage);
+            const char *unit = fty_proto_unit(bmessage);
+            uint32_t ttl = fty_proto_ttl(bmessage);
+            uint64_t timestamp = fty_proto_aux_number (bmessage, "time", ::time(NULL));
+            // TODO: 2016-04-27 ACE: fix it later, when "string" values
+            // in the metric would be considered as
+            // normal behaviour, but for now it is not supposed to be so
+            // -> generated error messages into the log
+            char *end;
+            double dvalue = strtod (value, &end);
+            if (errno == ERANGE) {
+                errno = 0;
+                fty_proto_print (bmessage);
+                zsys_error ("%s: can't convert value to double #1, ignore message", name);
+                fty_proto_destroy (&bmessage);
                 continue;
             }
-            if ( fty_proto_id(bmessage) == FTY_PROTO_METRIC )  {
-                // process as metric message
-                const char *type = fty_proto_type(bmessage);
-                const char * name = fty_proto_name (bmessage);
-                const char *value = fty_proto_value(bmessage);
-                const char *unit = fty_proto_unit(bmessage);
-                uint32_t ttl = fty_proto_ttl(bmessage);
-                uint64_t timestamp = fty_proto_aux_number (bmessage, "time", ::time(NULL));
-                // TODO: 2016-04-27 ACE: fix it later, when "string" values
-                // in the metric would be considered as
-                // normal behaviour, but for now it is not supposed to be so
-                // -> generated error messages into the log
-                char *end;
-                double dvalue = strtod (value, &end);
-                if (errno == ERANGE) {
-                    errno = 0;
-                    fty_proto_print (bmessage);
-                    zsys_error ("%s: can't convert value to double #1, ignore message", name);
-                    fty_proto_destroy (&bmessage);
-                    continue;
-                }
-                else if (end == value || *end != '\0') {
-                    fty_proto_print (bmessage);
-                    zsys_error ("%s: can't convert value to double #2, ignore message", name);
-                    fty_proto_destroy (&bmessage);
-                    continue;
-                }
-
-                zsys_debug1("%s: Got message '%s' with value %s", name, topic.c_str(), value);
-
-                // Update cache with new value
-                MetricInfo m (name, type, unit, dvalue, timestamp, "", ttl);
-                fty_proto_destroy(&bmessage);
-                cache.addMetric (m);
-                cache.removeOldMetrics();
-                evaluate_metric(client, m, cache, alertConfiguration);
+            else if (end == value || *end != '\0') {
+                fty_proto_print (bmessage);
+                zsys_error ("%s: can't convert value to double #2, ignore message", name);
+                fty_proto_destroy (&bmessage);
+                continue;
             }
+
+            zsys_debug1("%s: Got message '%s' with value %s", name, topic.c_str(), value);
+
+            // Update cache with new value
+            MetricInfo m (name, type, unit, dvalue, timestamp, "", ttl);
+            fty_proto_destroy(&bmessage);
+            cache.addMetric (m);
+            cache.removeOldMetrics();
+            evaluate_metric(client, m, cache, alertConfiguration);
             fty_proto_destroy (&bmessage);
         }
         // According RFC we expect here a messages
         // with the topic:
         //   * RULES_SUBJECT
-        else
-        if ( streq (mlm_client_subject (client), RULES_SUBJECT) ) {
+        if (zmessage && subject == RULES_SUBJECT) {
             zsys_debug1 ("%s", RULES_SUBJECT);
             // Here we can have:
             //  * request for list of rules
@@ -643,8 +675,7 @@ fty_alert_engine_server (zsock_t *pipe, void* args)
             }
             zstr_free (&command);
             zstr_free (&param);
-        }
-        else {
+        } else if (zmessage) {
             // Here we can have a message with arbitrary topic, but according protocol
             // first frame must be one of the following:
             //  * METRIC_UNAVAILABLE


### PR DESCRIPTION
Under higher load, it may happen that we do not empty the pipe fast
enough. This leads to first the agent not responding to mailbox messages
in time and the malamute outgoing queue filling. To avoid this, fetch
all pending metric updates before doing any evaluation and if the same
metric is received more than once, only consider the latest version. We
may miss some spikes and sags in the metrics this way, but we already
miss these by only polling once per 30 seconds.
