### PR TITLE
Problem: too much whitespace change obscures comparison

### DIFF
--- a/include/fty_alert_engine_server.h
+++ b/include/fty_alert_engine_server.h
@@ -17,7 +17,7 @@
     with this program; if not, write to the Free Software Foundation, Inc.,
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
     =========================================================================
- */
+*/
 
 #ifndef FTY_ALERT_ENGINE_SERVER_H_INCLUDED
 #define FTY_ALERT_ENGINE_SERVER_H_INCLUDED
@@ -27,20 +27,20 @@ extern "C" {
 #endif
 
 
-    //  @interface
-    FTY_ALERT_ENGINE_EXPORT void
-    fty_alert_engine_stream(zsock_t *pipe, void *args);
+//  @interface
+FTY_ALERT_ENGINE_EXPORT void
+    fty_alert_engine_stream (zsock_t *pipe, void *args);
 
-    FTY_ALERT_ENGINE_EXPORT void
-    fty_alert_engine_mailbox(zsock_t *pipe, void *args);
+FTY_ALERT_ENGINE_EXPORT void
+    fty_alert_engine_mailbox (zsock_t *pipe, void *args);
 
-    FTY_ALERT_ENGINE_EXPORT void
-    clearEvaluateMetrics();
+FTY_ALERT_ENGINE_EXPORT void
+    clearEvaluateMetrics ();
 
-    //  Self test of this class
-    FTY_ALERT_ENGINE_EXPORT void
-    fty_alert_engine_server_test(bool verbose);
-    //  @end
+//  Self test of this class
+FTY_ALERT_ENGINE_EXPORT void
+    fty_alert_engine_server_test (bool verbose);
+//  @end
 
 #ifdef __cplusplus
 }

--- a/src/autoconfig.cc
+++ b/src/autoconfig.cc
@@ -17,14 +17,14 @@
     with this program; if not, write to the Free Software Foundation, Inc.,
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
     =========================================================================
- */
+*/
 
 /*
 @header
     autoconfig - Autoconfig
 @discuss
 @end
- */
+*/
 
 #include "fty_alert_engine_classes.h"
 
@@ -54,218 +54,238 @@ const std::string Autoconfig::StateFile = "/var/lib/fty/fty-alert-engine/state";
 std::string Autoconfig::AlertEngineName;
 
 static int
-load_agent_info(std::string &info) {
-    if (!shared::is_file(Autoconfig::StateFile.c_str())) {
-        zsys_error("not a file");
+load_agent_info(std::string &info)
+{
+    if ( !shared::is_file (Autoconfig::StateFile.c_str ())) {
+        zsys_error ("not a file");
         info = "";
         return -1;
     }
     std::ifstream f(Autoconfig::StateFile, std::ios::in | std::ios::binary);
     if (f) {
-        f.seekg(0, std::ios::end);
-        info.resize(f.tellg());
-        f.seekg(0, std::ios::beg);
-        f.read(&info[0], info.size());
-        f.close();
+        f.seekg (0, std::ios::end);
+        info.resize (f.tellg ());
+        f.seekg (0, std::ios::beg);
+        f.read (&info[0], info.size());
+        f.close ();
         return 0;
     }
-    zsys_error("Fail to read '%s'", Autoconfig::StateFile.c_str());
+    zsys_error("Fail to read '%s'", Autoconfig::StateFile.c_str ());
     return -1;
 }
 
 static int
-save_agent_info(const std::string& json) {
-    if (!shared::is_dir(Autoconfig::StateFilePath.c_str())) {
-        zsys_error("Can't serialize state, '%s' is not directory", Autoconfig::StateFilePath.c_str());
+save_agent_info(const std::string& json)
+{
+    if (!shared::is_dir (Autoconfig::StateFilePath.c_str ())) {
+        zsys_error ("Can't serialize state, '%s' is not directory", Autoconfig::StateFilePath.c_str ());
         return -1;
     }
     try {
         std::ofstream f(Autoconfig::StateFile);
-        f.exceptions(~std::ofstream::goodbit);
+        f.exceptions (~std::ofstream::goodbit);
         f << json;
         f.close();
-    } catch (const std::exception& e) {
-        zsys_error("Can't serialize state, %s", e.what());
+    }
+    catch (const std::exception& e) {
+        zsys_error ("Can't serialize state, %s", e.what());
         return -1;
     }
     return 0;
 }
 
-inline void operator<<=(cxxtools::SerializationInfo& si, const AutoConfigurationInfo& info) {
+inline void operator<<= (cxxtools::SerializationInfo& si, const AutoConfigurationInfo& info)
+{
     si.setTypeName("AutoConfigurationInfo");
     si.addMember("type") <<= info.type;
     si.addMember("subtype") <<= info.subtype;
     si.addMember("operation") <<= info.operation;
     si.addMember("configured") <<= info.configured;
-    si.addMember("date") <<= std::to_string(info.date);
+    si.addMember("date") <<= std::to_string (info.date);
     si.addMember("attributes") <<= info.attributes;
 }
 
-inline void operator>>=(const cxxtools::SerializationInfo& si, AutoConfigurationInfo& info) {
+inline void operator>>= (const cxxtools::SerializationInfo& si, AutoConfigurationInfo& info)
+{
     std::string temp;
     si.getMember("configured") >>= info.configured;
     si.getMember("type") >>= temp;
     si.getMember("subtype") >>= temp;
     si.getMember("operation") >>= temp;
     si.getMember("date") >>= temp;
-    info.date = std::stoi(temp);
-    si.getMember("attributes") >>= info.attributes;
+    info.date = std::stoi (temp);
+    si.getMember("attributes")  >>= info.attributes;
 }
 
-void Autoconfig::main(zsock_t *pipe, char *name) {
-    if (_client) mlm_client_destroy(&_client);
-    _client = mlm_client_new();
-    assert(_client);
+void Autoconfig::main (zsock_t *pipe, char *name)
+{
+    if ( _client ) mlm_client_destroy( &_client );
+    _client = mlm_client_new ();
+    assert (_client);
 
-    zpoller_t *poller = zpoller_new(pipe, msgpipe(), NULL);
-    assert(poller);
-    _timestamp = zclock_mono();
-    zsock_signal(pipe, 0);
+    zpoller_t *poller = zpoller_new (pipe, msgpipe (), NULL);
+    assert (poller);
+    _timestamp = zclock_mono ();
+    zsock_signal (pipe, 0);
 
     while (!zsys_interrupted) {
-        void *which = zpoller_wait(poller, _timeout);
+        void *which = zpoller_wait (poller, _timeout);
         if (which == NULL) {
-            if (zpoller_terminated(poller) || zsys_interrupted) {
-                zsys_warning("zpoller_terminated () or zsys_interrupted ()");
+            if (zpoller_terminated (poller) || zsys_interrupted) {
+                zsys_warning ("zpoller_terminated () or zsys_interrupted ()");
                 break;
             }
-            if (zpoller_expired(poller)) {
-                onPoll();
-                _timestamp = zclock_mono();
+            if (zpoller_expired (poller)) {
+                onPoll ();
+                _timestamp = zclock_mono ();
                 continue;
             }
-            _timestamp = zclock_mono();
-            zsys_warning("zpoller_wait () returned NULL while at the same time zpoller_terminated == 0, zsys_interrupted == 0, zpoller_expired == 0");
+            _timestamp = zclock_mono ();
+            zsys_warning ("zpoller_wait () returned NULL while at the same time zpoller_terminated == 0, zsys_interrupted == 0, zpoller_expired == 0");
             continue;
         }
 
-        int64_t now = zclock_mono();
+        int64_t now = zclock_mono ();
         if (now - _timestamp >= _timeout) {
-            onPoll();
-            _timestamp = zclock_mono();
+            onPoll ();
+            _timestamp = zclock_mono ();
         }
 
         if (which == pipe) {
-            zmsg_t *msg = zmsg_recv(pipe);
-            char *cmd = zmsg_popstr(msg);
+            zmsg_t *msg = zmsg_recv (pipe);
+            char *cmd = zmsg_popstr (msg);
 
-            if (streq(cmd, "$TERM")) {
-                zsys_debug1("%s: $TERM received", name);
-                zstr_free(&cmd);
-                zmsg_destroy(&msg);
+            if (streq (cmd, "$TERM")) {
+                zsys_debug1 ("%s: $TERM received", name);
+                zstr_free (&cmd);
+                zmsg_destroy (&msg);
                 break;
-            } else
-                if (streq(cmd, "VERBOSE")) {
-                zsys_debug1("%s: VERBOSE received", name);
+            }
+            else
+                if (streq (cmd, "VERBOSE")) {
+                zsys_debug1 ("%s: VERBOSE received", name);
                 agent_alert_verbose = true;
-            } else
-                if (streq(cmd, "TEMPLATES_DIR")) {
-                zsys_debug1("TEMPLATES_DIR received");
-                char* dirname = zmsg_popstr(msg);
+            }
+            else
+                if (streq (cmd, "TEMPLATES_DIR")) {
+                zsys_debug1 ("TEMPLATES_DIR received");
+                char* dirname = zmsg_popstr (msg);
                 if (dirname) {
-                    Autoconfig::RuleFilePath = std::string(dirname);
+                    Autoconfig::RuleFilePath = std::string (dirname);
                 } else {
-                    zsys_error("%s: in TEMPLATES_DIR command next frame is missing", name);
+                    zsys_error ("%s: in TEMPLATES_DIR command next frame is missing", name);
                 }
-                zstr_free(&dirname);
-            } else
-                if (streq(cmd, "CONNECT")) {
-                zsys_debug1("CONNECT received");
-                char* endpoint = zmsg_popstr(msg);
-                int rv = mlm_client_connect(_client, endpoint, 1000, name);
+                zstr_free (&dirname);
+            }
+            else
+                if (streq (cmd, "CONNECT")) {
+                zsys_debug1 ("CONNECT received");
+                char* endpoint = zmsg_popstr (msg);
+                int rv = mlm_client_connect (_client, endpoint, 1000, name);
                 if (rv == -1)
-                    zsys_error("%s: can't connect to malamute endpoint '%s'", name, endpoint);
-                zstr_free(&endpoint);
-            } else
-                if (streq(cmd, "CONSUMER")) {
-                zsys_debug1("CONSUMER received");
-                char* stream = zmsg_popstr(msg);
-                char* pattern = zmsg_popstr(msg);
-                int rv = mlm_client_set_consumer(_client, stream, pattern);
+                    zsys_error ("%s: can't connect to malamute endpoint '%s'", name, endpoint);
+                zstr_free (&endpoint);
+            }
+            else
+                if (streq (cmd, "CONSUMER")) {
+                zsys_debug1 ("CONSUMER received");
+                char* stream = zmsg_popstr (msg);
+                char* pattern = zmsg_popstr (msg);
+                int rv = mlm_client_set_consumer (_client, stream, pattern);
                 if (rv == -1)
-                    zsys_error("%s: can't set consumer on stream '%s', '%s'", name, stream, pattern);
-                zstr_free(&pattern);
-                zstr_free(&stream);
-            } else
-                if (streq(cmd, "ALERT_ENGINE_NAME")) {
-                zsys_debug1("ALERT_ENGINE_NAME received");
-                char* alert_engine_name = zmsg_popstr(msg);
+                    zsys_error ("%s: can't set consumer on stream '%s', '%s'", name, stream, pattern);
+                zstr_free (&pattern);
+                zstr_free (&stream);
+            }
+            else
+                if (streq (cmd, "ALERT_ENGINE_NAME")) {
+                zsys_debug1 ("ALERT_ENGINE_NAME received");
+                char* alert_engine_name = zmsg_popstr (msg);
                 if (alert_engine_name) {
-                    Autoconfig::AlertEngineName = std::string(alert_engine_name);
-                } else {
-                    zsys_error("%s: in ALERT_ENGINE_NAME command next frame is missing", name);
+                    Autoconfig::AlertEngineName = std::string (alert_engine_name);
                 }
-                zstr_free(&alert_engine_name);
+                else {
+                    zsys_error ("%s: in ALERT_ENGINE_NAME command next frame is missing", name);
+                }
+                zstr_free (&alert_engine_name);
             }
 
-            zstr_free(&cmd);
-            zmsg_destroy(&msg);
+            zstr_free (&cmd);
+            zmsg_destroy (&msg);
             continue;
         }
 
-        zmsg_t *message = recv();
+        zmsg_t *message = recv ();
         if (!message) {
-            zsys_warning("recv () returned NULL; zsys_interrupted == '%s'; command = '%s', subject = '%s', sender = '%s'",
-                    zsys_interrupted ? "true" : "false", command(), subject(), sender());
+            zsys_warning ("recv () returned NULL; zsys_interrupted == '%s'; command = '%s', subject = '%s', sender = '%s'",
+                    zsys_interrupted ? "true" : "false", command (), subject (), sender ());
             continue;
         }
-        if (is_fty_proto(message)) {
-            fty_proto_t *bmessage = fty_proto_decode(&message);
-            if (!bmessage) {
-                zsys_error("can't decode message with subject %s, ignoring", subject());
+        if (is_fty_proto (message)) {
+            fty_proto_t *bmessage = fty_proto_decode (&message);
+            if (!bmessage ) {
+                zsys_error ("can't decode message with subject %s, ignoring", subject ());
                 continue;
             }
 
-            if (fty_proto_id(bmessage) == FTY_PROTO_ASSET) {
+            if (fty_proto_id (bmessage) == FTY_PROTO_ASSET) {
                 if (!streq(fty_proto_operation(bmessage), FTY_PROTO_ASSET_OP_INVENTORY)) {
-                    onSend(&bmessage);
+                    onSend (&bmessage);
                 }
-                fty_proto_destroy(&bmessage);
-                continue;
-            } else {
-                zsys_warning("Weird fty_proto msg received, id = '%d', command = '%s', subject = '%s', sender = '%s'",
-                        fty_proto_id(bmessage), command(), subject(), sender());
-                fty_proto_destroy(&bmessage);
+                fty_proto_destroy (&bmessage);
                 continue;
             }
-        } else {
+            else {
+                zsys_warning ("Weird fty_proto msg received, id = '%d', command = '%s', subject = '%s', sender = '%s'",
+                        fty_proto_id (bmessage), command (), subject (), sender ());
+                fty_proto_destroy (&bmessage);
+                continue;
+            }
+        }
+        else {
             // this should be a message from ALERT_ENGINE_NAME (fty-alert-engine or fty-alert-flexible)
-            if (streq(sender(), "fty-alert-engine") ||
-                    streq(sender(), "fty-alert-flexible")) {
-                char *reply = zmsg_popstr(message);
-                if (streq(reply, "OK")) {
-                    char *details = zmsg_popstr(message);
-                    zsys_debug("Received OK for rule '%s'", details);
-                    zstr_free(&details);
-                } else {
-                    if (streq(reply, "ERROR")) {
-                        char *details = zmsg_popstr(message);
-                        zsys_error("Received ERROR : '%s'", details);
-                        zstr_free(&details);
-                    } else
-                        zsys_warning("Unexpected message received, command = '%s', subject = '%s', sender = '%s'",
-                            command(), subject(), sender());
+            if (streq (sender (), "fty-alert-engine") ||
+                streq (sender (), "fty-alert-flexible"))
+            {
+                char *reply = zmsg_popstr (message);
+                if (streq (reply, "OK")) {
+                    char *details = zmsg_popstr (message);
+                    zsys_debug ("Received OK for rule '%s'", details);
+                    zstr_free (&details);
                 }
-                zstr_free(&reply);
-            } else
-                zsys_warning("Message from unknown sender received: sender = '%s', command = '%s', subject = '%s'.",
-                    sender(), command(), subject());
-            zmsg_destroy(&message);
+                else {
+                    if (streq (reply, "ERROR")) {
+                        char *details = zmsg_popstr (message);
+                        zsys_error ("Received ERROR : '%s'", details);
+                        zstr_free (&details);
+                    }
+                    else
+                        zsys_warning ("Unexpected message received, command = '%s', subject = '%s', sender = '%s'",
+                            command (), subject (), sender ());
+                }
+                zstr_free (&reply);
+            }
+            else
+                zsys_warning ("Message from unknown sender received: sender = '%s', command = '%s', subject = '%s'.",
+                    sender (), command (), subject ());
+            zmsg_destroy (&message);
         }
     }
-    zpoller_destroy(&poller);
+    zpoller_destroy (&poller);
 }
 
-const std::string Autoconfig::getEname(const std::string &iname) {
+const std::string Autoconfig::getEname (const std::string &iname)
+{
     std::string ename;
-    auto search = _containers.find(iname); // iname | ename
-    if (search != _containers.end())
+    auto search = _containers.find (iname); // iname | ename
+    if (search != _containers.end ())
         ename = search->second;
     return ename;
 }
 
 void
-Autoconfig::onSend(fty_proto_t **message) {
+Autoconfig::onSend (fty_proto_t **message)
+{
     if (!message || ! *message)
         return;
 
@@ -293,11 +313,11 @@ Autoconfig::onSend(fty_proto_t **message) {
             try {
                 _containers.erase(device_name);
             } catch (const std::exception &e) {
-                zsys_error("can't erase container %s: %s", device_name.c_str(), e.what());
+                zsys_error( "can't erase container %s: %s", device_name.c_str(), e.what() );
             }
         }
     }
-    if (info.type.empty()) {
+    if (info.type.empty ()) {
         zsys_debug("extracting attributes from asset message failed.");
         return;
     }
@@ -308,22 +328,23 @@ Autoconfig::onSend(fty_proto_t **message) {
     }
 
     zsys_debug("Decoded asset message - device name = '%s', type = '%s', subtype = '%s', operation = '%s'",
-            device_name.c_str(), info.type.c_str(), info.subtype.c_str(), info.operation.c_str());
-    info.attributes = utils::zhash_to_map(fty_proto_ext(*message));
+            device_name.c_str (), info.type.c_str (), info.subtype.c_str (), info.operation.c_str ());
+    info.attributes = utils::zhash_to_map(fty_proto_ext (*message));
     if (info.operation != "delete") {
         _configurableDevices[device_name] = info;
     } else {
         try {
             _configurableDevices.erase(device_name);
         } catch (const std::exception &e) {
-            zsys_error("can't erase device %s: %s", device_name.c_str(), e.what());
+            zsys_error( "can't erase device %s: %s", device_name.c_str(), e.what() );
         }
     }
-    saveState();
+    saveState ();
     setPollingInterval();
 }
 
-void Autoconfig::onPoll() {
+void Autoconfig::onPoll( )
+{
     static TemplateRuleConfigurator iTemplateRuleConfigurator;
 
     bool save = false;
@@ -337,25 +358,29 @@ void Autoconfig::onPoll() {
         if (zsys_interrupted)
             return;
 
-        if ((&iTemplateRuleConfigurator)->isApplicable(it.second)) {
+        if ((&iTemplateRuleConfigurator)->isApplicable (it.second))
+        {
             std::string la;
-            for (auto &i : it.second.attributes) {
+            for (auto &i : it.second.attributes)
+            {
                 if (i.first == "logical_asset")
                     la = i.second;
             }
 
-            device_configured &= (&iTemplateRuleConfigurator)->configure(it.first, it.second, Autoconfig::getEname(la), client());
-        } else
-            zsys_info("No applicable configurator for device '%s', not configuring", it.first.c_str());
+            device_configured &= (&iTemplateRuleConfigurator)->configure (it.first, it.second, Autoconfig::getEname (la), client ());
+        }
+        else
+            zsys_info ("No applicable configurator for device '%s', not configuring", it.first.c_str ());
 
         if (device_configured) {
-            zsys_debug("Device '%s' configured successfully", it.first.c_str());
+            zsys_debug ("Device '%s' configured successfully", it.first.c_str ());
             it.second.configured = true;
             save = true;
-        } else {
-            zsys_debug("Device '%s' NOT configured yet.", it.first.c_str());
         }
-        it.second.date = zclock_mono();
+        else {
+            zsys_debug ("Device '%s' NOT configured yet.", it.first.c_str ());
+        }
+        it.second.date = zclock_mono ();
     }
 
     if (save) {
@@ -367,11 +392,12 @@ void Autoconfig::onPoll() {
 
 // autoconfig agent private methods
 
-void Autoconfig::setPollingInterval() {
+void Autoconfig::setPollingInterval( )
+{
     _timeout = -1;
-    for (auto &it : _configurableDevices) {
-        if (!it.second.configured) {
-            if (it.second.date == 0) {
+    for ( auto &it : _configurableDevices) {
+        if ( ! it.second.configured ) {
+            if ( it.second.date == 0 ) {
                 // there is device that we didn't try to configure
                 // let's try to do it soon
                 _timeout = 5000;
@@ -385,10 +411,11 @@ void Autoconfig::setPollingInterval() {
     }
 }
 
-void Autoconfig::loadState() {
+void Autoconfig::loadState()
+{
     std::string json = "";
     int rv = load_agent_info(json);
-    if (rv != 0 || json.empty())
+    if ( rv != 0 || json.empty() )
         return;
 
     try {
@@ -397,38 +424,43 @@ void Autoconfig::loadState() {
         cxxtools::JsonDeserializer deserializer(in);
         deserializer.deserialize(_configurableDevices);
     } catch (const std::exception &e) {
-        zsys_error("can't parse state: %s", e.what());
+        zsys_error( "can't parse state: %s", e.what() );
     }
 }
 
-void Autoconfig::cleanupState() {
-    zsys_debug("State file size before cleanup '%zu'", _configurableDevices.size());
+void Autoconfig::cleanupState()
+{
+    zsys_debug ("State file size before cleanup '%zu'", _configurableDevices.size ());
+
     // Just set the state file to empty
     save_agent_info("");
     return;
 }
 
-void Autoconfig::saveState() {
+void Autoconfig::saveState()
+{
     std::ostringstream stream;
     cxxtools::JsonSerializer serializer(stream);
-    zsys_debug("%s: State file size = '%zu'", __FUNCTION__, _configurableDevices.size());
-    serializer.serialize(_configurableDevices);
+    zsys_debug ("%s: State file size = '%zu'", __FUNCTION__, _configurableDevices.size ());
+    serializer.serialize( _configurableDevices );
     serializer.finish();
     std::string json = stream.str();
-    zsys_debug(json.c_str());
-    save_agent_info(json);
+    zsys_debug (json.c_str ());
+    save_agent_info(json );
 }
 
-void autoconfig(zsock_t *pipe, void *args) {
-    char *name = (char *) args;
-    zsys_info("autoconfig agent started");
-    Autoconfig agent(AUTOCONFIG);
+void autoconfig (zsock_t *pipe, void *args )
+{
+    char *name = (char *)args;
+    zsys_info ("autoconfig agent started");
+    Autoconfig agent( AUTOCONFIG );
     agent.run(pipe, name);
-    zsys_info("autoconfig agent exited");
+    zsys_info ("autoconfig agent exited");
 }
 
 void
-autoconfig_test(bool verbose) {
-    printf(" * autoconfig: ");
-    printf("OK\n");
+autoconfig_test (bool verbose)
+{
+    printf (" * autoconfig: ");
+    printf ("OK\n");
 }

--- a/src/autoconfig.cc
+++ b/src/autoconfig.cc
@@ -163,52 +163,53 @@ void Autoconfig::main (zsock_t *pipe, char *name)
             }
             else
                 if (streq (cmd, "VERBOSE")) {
-                zsys_debug1 ("%s: VERBOSE received", name);
-                agent_alert_verbose = true;
-            }
-            else
-                if (streq (cmd, "TEMPLATES_DIR")) {
-                zsys_debug1 ("TEMPLATES_DIR received");
-                char* dirname = zmsg_popstr (msg);
-                if (dirname) {
-                    Autoconfig::RuleFilePath = std::string (dirname);
-                } else {
-                    zsys_error ("%s: in TEMPLATES_DIR command next frame is missing", name);
+                    zsys_debug1 ("%s: VERBOSE received", name);
+                    agent_alert_verbose = true;
                 }
-                zstr_free (&dirname);
-            }
-            else
-                if (streq (cmd, "CONNECT")) {
-                zsys_debug1 ("CONNECT received");
-                char* endpoint = zmsg_popstr (msg);
-                int rv = mlm_client_connect (_client, endpoint, 1000, name);
-                if (rv == -1)
-                    zsys_error ("%s: can't connect to malamute endpoint '%s'", name, endpoint);
-                zstr_free (&endpoint);
-            }
-            else
-                if (streq (cmd, "CONSUMER")) {
-                zsys_debug1 ("CONSUMER received");
-                char* stream = zmsg_popstr (msg);
-                char* pattern = zmsg_popstr (msg);
-                int rv = mlm_client_set_consumer (_client, stream, pattern);
-                if (rv == -1)
-                    zsys_error ("%s: can't set consumer on stream '%s', '%s'", name, stream, pattern);
-                zstr_free (&pattern);
-                zstr_free (&stream);
-            }
-            else
-                if (streq (cmd, "ALERT_ENGINE_NAME")) {
-                zsys_debug1 ("ALERT_ENGINE_NAME received");
-                char* alert_engine_name = zmsg_popstr (msg);
-                if (alert_engine_name) {
-                    Autoconfig::AlertEngineName = std::string (alert_engine_name);
-                }
-                else {
-                    zsys_error ("%s: in ALERT_ENGINE_NAME command next frame is missing", name);
-                }
-                zstr_free (&alert_engine_name);
-            }
+                else
+                    if (streq (cmd, "TEMPLATES_DIR")) {
+                        zsys_debug1 ("TEMPLATES_DIR received");
+                        char* dirname = zmsg_popstr (msg);
+                        if (dirname) {
+                            Autoconfig::RuleFilePath = std::string (dirname);
+                        }
+                        else {
+                            zsys_error ("%s: in TEMPLATES_DIR command next frame is missing", name);
+                        }
+                        zstr_free (&dirname);
+                    }
+                    else
+                        if (streq (cmd, "CONNECT")) {
+                            zsys_debug1 ("CONNECT received");
+                            char* endpoint = zmsg_popstr (msg);
+                            int rv = mlm_client_connect (_client, endpoint, 1000, name);
+                            if (rv == -1)
+                                zsys_error ("%s: can't connect to malamute endpoint '%s'", name, endpoint);
+                            zstr_free (&endpoint);
+                        }
+                        else
+                            if (streq (cmd, "CONSUMER")) {
+                                zsys_debug1 ("CONSUMER received");
+                                char* stream = zmsg_popstr (msg);
+                                char* pattern = zmsg_popstr (msg);
+                                int rv = mlm_client_set_consumer (_client, stream, pattern);
+                                if (rv == -1)
+                                    zsys_error ("%s: can't set consumer on stream '%s', '%s'", name, stream, pattern);
+                                zstr_free (&pattern);
+                                zstr_free (&stream);
+                            }
+                            else
+                                if (streq (cmd, "ALERT_ENGINE_NAME")) {
+                                    zsys_debug1 ("ALERT_ENGINE_NAME received");
+                                    char* alert_engine_name = zmsg_popstr (msg);
+                                    if (alert_engine_name) {
+                                        Autoconfig::AlertEngineName = std::string (alert_engine_name);
+                                    }
+                                    else {
+                                        zsys_error ("%s: in ALERT_ENGINE_NAME command next frame is missing", name);
+                                    }
+                                    zstr_free (&alert_engine_name);
+                                }
 
             zstr_free (&cmd);
             zmsg_destroy (&msg);

--- a/src/fty_alert_actions.cc
+++ b/src/fty_alert_actions.cc
@@ -17,14 +17,14 @@
     with this program; if not, write to the Free Software Foundation, Inc.,
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
     =========================================================================
- */
+*/
 
 /*
 @header
     fty_alert_actions - Actor performing actions on alert (sending notifications)
 @discuss
 @end
- */
+*/
 
 #include "fty_alert_engine_classes.h"
 
@@ -90,9 +90,9 @@
         return (void *)(0 == zlist_size(testing_var_recv) ? NULL : (void *)1); \
     }
 #ifdef __GNUC__
-#define unlikely(x) __builtin_expect(0 != x, 0)
+    #define unlikely(x) __builtin_expect(0 != x, 0)
 #else
-#define unlikely(x) (0 != x)
+    #define unlikely(x) (0 != x)
 #endif
 #define zpoller_wait(...) \
     (unlikely(testing) ? (testing_fun_wait(__LINE__,__FUNCTION__)) : (zpoller_wait(__VA_ARGS__)))
@@ -141,39 +141,39 @@ TEST_VARS
 TEST_FUNCTIONS
 
 
-        char verbose = 0;
+char verbose = 0;
 static const std::map <std::pair <std::string, uint8_t>, uint32_t> times = {
-    {{"CRITICAL", 1}, 5 * 60},
-    {{"CRITICAL", 2}, 15 * 60},
-    {{"CRITICAL", 3}, 15 * 60},
-    {{"CRITICAL", 4}, 15 * 60},
-    {{"CRITICAL", 5}, 15 * 60},
-    {{"WARNING", 1}, 1 * 60 * 60},
-    {{"WARNING", 2}, 4 * 60 * 60},
-    {{"WARNING", 3}, 4 * 60 * 60},
-    {{"WARNING", 4}, 4 * 60 * 60},
-    {{"WARNING", 5}, 4 * 60 * 60},
-    {{"INFO", 1}, 8 * 60 * 60},
-    {{"INFO", 2}, 24 * 60 * 60},
-    {{"INFO", 3}, 24 * 60 * 60},
-    {{"INFO", 4}, 24 * 60 * 60},
-    {{"INFO", 5}, 24 * 60 * 60}
+    { {"CRITICAL", 1}, 5  * 60},
+    { {"CRITICAL", 2}, 15 * 60},
+    { {"CRITICAL", 3}, 15 * 60},
+    { {"CRITICAL", 4}, 15 * 60},
+    { {"CRITICAL", 5}, 15 * 60},
+    { {"WARNING", 1}, 1 * 60 * 60},
+    { {"WARNING", 2}, 4 * 60 * 60},
+    { {"WARNING", 3}, 4 * 60 * 60},
+    { {"WARNING", 4}, 4 * 60 * 60},
+    { {"WARNING", 5}, 4 * 60 * 60},
+    { {"INFO", 1}, 8 * 60 * 60},
+    { {"INFO", 2}, 24 * 60 * 60},
+    { {"INFO", 3}, 24 * 60 * 60},
+    { {"INFO", 4}, 24 * 60 * 60},
+    { {"INFO", 5}, 24 * 60 * 60}
 };
 
 
 //  Structure of our class
 
 struct _fty_alert_actions_t {
-    mlm_client_t *client;
-    mlm_client_t *requestreply_client;
-    zpoller_t *requestreply_poller;
-    zhash_t *alerts_cache;
-    zhash_t *assets_cache;
-    char *name;
-    char *requestreply_name;
-    bool integration_test;
-    uint64_t notification_override;
-    uint64_t requestreply_timeout;
+    mlm_client_t    *client;
+    mlm_client_t    *requestreply_client;
+    zpoller_t       *requestreply_poller;
+    zhash_t         *alerts_cache;
+    zhash_t         *assets_cache;
+    char            *name;
+    char            *requestreply_name;
+    bool            integration_test;
+    uint64_t        notification_override;
+    uint64_t        requestreply_timeout;
 };
 
 typedef struct {
@@ -185,35 +185,35 @@ typedef struct {
 
 
 // Forward declaration for function sanity
-static void s_handle_stream_deliver_alert(fty_alert_actions_t *, fty_proto_t **, const char *);
-static void s_handle_stream_deliver_asset(fty_alert_actions_t *, fty_proto_t **, const char *);
+static void s_handle_stream_deliver_alert (fty_alert_actions_t *, fty_proto_t **, const char *);
+static void s_handle_stream_deliver_asset (fty_alert_actions_t *, fty_proto_t **, const char *);
 
 
 //  --------------------------------------------------------------------------
 //  Fty proto destroy wrapper for freefn
-
-void fty_proto_destroy_wrapper(void *x) {
-    fty_proto_destroy((fty_proto_t **) & x);
+void fty_proto_destroy_wrapper (void *x) {
+    fty_proto_destroy ((fty_proto_t **) &x);
 }
 
 //  --------------------------------------------------------------------------
 //  Create a new fty_alert_actions
 
 fty_alert_actions_t *
-fty_alert_actions_new(void) {
-    fty_alert_actions_t *self = (fty_alert_actions_t *) zmalloc(sizeof (fty_alert_actions_t));
-    assert(self);
+fty_alert_actions_new (void)
+{
+    fty_alert_actions_t *self = (fty_alert_actions_t *) zmalloc (sizeof (fty_alert_actions_t));
+    assert (self);
     //  Initialize class properties here
-    self->client = mlm_client_new();
-    assert(self->client);
-    self->requestreply_client = mlm_client_new();
-    assert(self->requestreply_client);
-    self->requestreply_poller = zpoller_new(mlm_client_msgpipe(self->requestreply_client), NULL);
-    assert(self->requestreply_poller);
-    self->alerts_cache = zhash_new();
-    assert(self->alerts_cache);
-    self->assets_cache = zhash_new();
-    assert(self->assets_cache);
+    self->client = mlm_client_new ();
+    assert (self->client);
+    self->requestreply_client = mlm_client_new ();
+    assert (self->requestreply_client);
+    self->requestreply_poller = zpoller_new (mlm_client_msgpipe (self->requestreply_client), NULL);
+    assert (self->requestreply_poller);
+    self->alerts_cache = zhash_new ();
+    assert (self->alerts_cache);
+    self->assets_cache = zhash_new ();
+    assert (self->assets_cache);
     self->integration_test = false;
     self->notification_override = 0;
     self->name = NULL;
@@ -226,31 +226,32 @@ fty_alert_actions_new(void) {
 //  Destroy the fty_alert_actions
 
 void
-fty_alert_actions_destroy(fty_alert_actions_t **self_p) {
-    assert(self_p);
+fty_alert_actions_destroy (fty_alert_actions_t **self_p)
+{
+    assert (self_p);
     if (*self_p) {
         fty_alert_actions_t *self = *self_p;
         //  Free class properties here
         //  Free object itself
         if (NULL != self->client) {
-            mlm_client_destroy(&self->client);
+            mlm_client_destroy (&self->client);
         }
         if (NULL != self->requestreply_poller) {
-            zpoller_destroy(&self->requestreply_poller);
+            zpoller_destroy (&self->requestreply_poller);
         }
         if (NULL != self->requestreply_client) {
-            mlm_client_destroy(&self->requestreply_client);
+            mlm_client_destroy (&self->requestreply_client);
         }
         if (NULL != self->alerts_cache) {
-            zhash_destroy(&self->alerts_cache);
+            zhash_destroy (&self->alerts_cache);
         }
         if (NULL != self->assets_cache) {
-            zhash_destroy(&self->assets_cache);
+            zhash_destroy (&self->assets_cache);
         }
         if (NULL != self->requestreply_name) {
             zstr_free(&self->requestreply_name);
         }
-        free(self);
+        free (self);
         *self_p = NULL;
     }
 }
@@ -260,7 +261,8 @@ fty_alert_actions_destroy(fty_alert_actions_t **self_p) {
 //  Calculate alert interval for asset based on severity and priority
 
 uint64_t
-get_alert_interval(s_alert_cache *alert_cache, uint64_t override_time = 0) {
+get_alert_interval(s_alert_cache *alert_cache, uint64_t override_time = 0)
+{
     if (override_time > 0) {
         return override_time;
     }
@@ -280,7 +282,8 @@ get_alert_interval(s_alert_cache *alert_cache, uint64_t override_time = 0) {
 //  Create new cache object
 
 s_alert_cache *
-new_alert_cache_item(fty_alert_actions_t *self, fty_proto_t *msg) {
+new_alert_cache_item(fty_alert_actions_t *self, fty_proto_t *msg)
+{
     assert(self);
     assert(msg);
     assert(fty_proto_name(msg));
@@ -293,24 +296,25 @@ new_alert_cache_item(fty_alert_actions_t *self, fty_proto_t *msg) {
     c->related_asset = (fty_proto_t *) zhash_lookup(self->assets_cache, fty_proto_name(msg));
     if (NULL == c->related_asset && !self->integration_test) {
         // we don't know an asset we receieved alert about, ask fty-asset about it
-        zsys_debug("fty_alert_actions: ask ASSET AGENT for ASSET_DETAIL about %s", fty_proto_name(msg));
-        zuuid_t *uuid = zuuid_new();
-        mlm_client_sendtox(self->requestreply_client, FTY_ASSET_AGENT_ADDRESS, "ASSET_DETAIL", "GET",
-                zuuid_str_canonical(uuid), fty_proto_name(msg), NULL);
-        void *which = zpoller_wait(self->requestreply_poller, self->requestreply_timeout);
+        zsys_debug ("fty_alert_actions: ask ASSET AGENT for ASSET_DETAIL about %s", fty_proto_name(msg));
+        zuuid_t *uuid = zuuid_new ();
+        mlm_client_sendtox (self->requestreply_client, FTY_ASSET_AGENT_ADDRESS, "ASSET_DETAIL", "GET",
+                zuuid_str_canonical (uuid), fty_proto_name(msg), NULL);
+        void *which = zpoller_wait (self->requestreply_poller, self->requestreply_timeout);
         if (which == NULL) {
             zsys_warning("fty_alert_actions: no response from ASSET AGENT, ignoring this alert.");
             free(c);
             c = NULL;
         } else {
-            zmsg_t *reply_msg = mlm_client_recv(self->requestreply_client);
-            char *rcv_uuid = zmsg_popstr(reply_msg);
-            if (0 == strcmp(rcv_uuid, zuuid_str_canonical(uuid)) && fty_proto_is(reply_msg)) {
+            zmsg_t *reply_msg = mlm_client_recv (self->requestreply_client);
+            char *rcv_uuid = zmsg_popstr (reply_msg);
+            if (0 == strcmp (rcv_uuid, zuuid_str_canonical (uuid)) && fty_proto_is (reply_msg)) {
                 zsys_debug("fty_alert_actions: receieved alert for unknown asset, asked for it and was successful.");
-                fty_proto_t *reply_proto_msg = fty_proto_decode(&reply_msg);
-                s_handle_stream_deliver_asset(self, &reply_proto_msg, mlm_client_subject(self->client));
+                fty_proto_t *reply_proto_msg = fty_proto_decode (&reply_msg);
+                s_handle_stream_deliver_asset (self, &reply_proto_msg, mlm_client_subject (self->client));
                 c->related_asset = (fty_proto_t *) zhash_lookup(self->assets_cache, fty_proto_name(msg));
-            } else {
+            }
+            else {
                 zsys_warning("fty_alert_actions: receieved alert for unknown asset, ignoring.");
                 if (reply_msg) {
                     zmsg_destroy(&reply_msg);
@@ -321,7 +325,7 @@ new_alert_cache_item(fty_alert_actions_t *self, fty_proto_t *msg) {
             }
             zstr_free(&rcv_uuid);
         }
-        zuuid_destroy(&uuid);
+        zuuid_destroy (&uuid);
     }
     return c;
 }
@@ -331,8 +335,9 @@ new_alert_cache_item(fty_alert_actions_t *self, fty_proto_t *msg) {
 //  Destroy cache object
 
 void
-delete_alert_cache_item(void *c) {
-    fty_proto_destroy(&((s_alert_cache *) c)->alert_msg);
+delete_alert_cache_item(void *c)
+{
+    fty_proto_destroy (&((s_alert_cache *)c)->alert_msg);
     free(c);
 }
 
@@ -341,57 +346,58 @@ delete_alert_cache_item(void *c) {
 //  Send email containing alert message
 
 void
-send_email(fty_alert_actions_t *self, s_alert_cache *alert_item, char action_email) {
+send_email(fty_alert_actions_t *self, s_alert_cache *alert_item, char action_email)
+{
     zsys_debug("fty_alert_actions: sending SENDMAIL_ALERT/SENDSMS_ALERT");
     fty_proto_t *alert_dup = fty_proto_dup(alert_item->alert_msg);
     zmsg_t *email_msg = fty_proto_encode(&alert_dup);
-    zuuid_t *uuid = zuuid_new();
+    zuuid_t *uuid = zuuid_new ();
     char *subject = NULL;
     const char *sname = fty_proto_ext_string(alert_item->related_asset, "name", "");
     if (EMAIL_ACTION_VALUE == action_email) {
         const char *contact_email = fty_proto_ext_string(alert_item->related_asset, "contact_email", "");
-        zmsg_pushstr(email_msg, contact_email);
+        zmsg_pushstr (email_msg, contact_email);
         subject = (char *) "SENDMAIL_ALERT";
     } else {
         const char *contact_sms = fty_proto_ext_string(alert_item->related_asset, "contact_sms", "");
-        zmsg_pushstr(email_msg, contact_sms);
+        zmsg_pushstr (email_msg, contact_sms);
         subject = (char *) "SENDSMS_ALERT";
     }
     const char *priority = fty_proto_aux_string(alert_item->related_asset, "priority", "");
-    zmsg_pushstr(email_msg, sname);
-    zmsg_pushstr(email_msg, priority);
-    zmsg_pushstr(email_msg, zuuid_str_canonical(uuid));
+    zmsg_pushstr (email_msg, sname);
+    zmsg_pushstr (email_msg, priority);
+    zmsg_pushstr (email_msg, zuuid_str_canonical (uuid));
     const char *address = (self->integration_test) ? FTY_EMAIL_AGENT_ADDRESS_TEST : FTY_EMAIL_AGENT_ADDRESS;
-    int rv = mlm_client_sendto(self->requestreply_client, address, subject, NULL, 5000, &email_msg);
+    int rv = mlm_client_sendto (self->requestreply_client, address, subject, NULL, 5000, &email_msg);
     if (rv != 0) {
-        zsys_error("fty_alert_actions: cannot send %s message", subject);
-        zuuid_destroy(&uuid);
-        zmsg_destroy(&email_msg);
+        zsys_error ("fty_alert_actions: cannot send %s message", subject);
+        zuuid_destroy (&uuid);
+        zmsg_destroy (&email_msg);
         return;
     }
-    void *which = zpoller_wait(self->requestreply_poller, self->requestreply_timeout);
+    void *which = zpoller_wait (self->requestreply_poller, self->requestreply_timeout);
     if (which == NULL) {
-        zsys_error("fty_alert_actions: received no reply on %s message", subject);
+        zsys_error ("fty_alert_actions: received no reply on %s message", subject);
     } else {
-        zmsg_t *reply_msg = mlm_client_recv(self->requestreply_client);
-        char *rcv_uuid = zmsg_popstr(reply_msg);
-        if (0 == strcmp(rcv_uuid, zuuid_str_canonical(uuid))) {
-            char *cmd = zmsg_popstr(reply_msg);
+        zmsg_t *reply_msg = mlm_client_recv (self->requestreply_client);
+        char *rcv_uuid = zmsg_popstr (reply_msg);
+        if (0 == strcmp (rcv_uuid, zuuid_str_canonical (uuid))) {
+            char *cmd = zmsg_popstr (reply_msg);
             if (0 == strcmp(cmd, "OK")) {
-                zsys_debug("fty_alert_actions: %s successful", subject);
+                zsys_debug ("fty_alert_actions: %s successful", subject);
             } else {
-                char *cause = zmsg_popstr(reply_msg);
-                zsys_error("fty_alert_actions: %s failed due to %s", subject, cause);
+                char *cause = zmsg_popstr (reply_msg);
+                zsys_error ("fty_alert_actions: %s failed due to %s", subject, cause);
                 zstr_free(&cause);
             }
             zstr_free(&cmd);
         } else {
-            zsys_error("fty_alert_actions: received invalid reply on %s message", subject);
+            zsys_error ("fty_alert_actions: received invalid reply on %s message", subject);
         }
         zstr_free(&rcv_uuid);
-        zmsg_destroy(&reply_msg);
+        zmsg_destroy (&reply_msg);
     }
-    zuuid_destroy(&uuid);
+    zuuid_destroy (&uuid);
 }
 
 
@@ -399,44 +405,47 @@ send_email(fty_alert_actions_t *self, s_alert_cache *alert_item, char action_ema
 //  Send message to sensor-gpoi to set gpo to desired state
 
 void
-send_gpo_action(fty_alert_actions_t *self, char *gpo_iname, char *gpo_state) {
+send_gpo_action(fty_alert_actions_t *self, char *gpo_iname, char *gpo_state)
+{
     zsys_debug("fty_alert_actions: sending GPO_INTERACTION to %s", gpo_iname);
     zuuid_t *zuuid = zuuid_new ();
     const char *address = (self->integration_test) ? FTY_SENSOR_GPIO_AGENT_ADDRESS_TEST : FTY_SENSOR_GPIO_AGENT_ADDRESS;
     int rv = mlm_client_sendtox
-            (self->requestreply_client,
-            address,
-            "GPO_INTERACTION",
-            zuuid_str_canonical(zuuid),
-            gpo_iname,
-            gpo_state,
-            NULL);
+                (self->requestreply_client,
+                 address,
+                 "GPO_INTERACTION",
+                 zuuid_str_canonical (zuuid),
+                 gpo_iname,
+                 gpo_state,
+                 NULL);
     if (rv != 0) {
-        zsys_error("fty_alert_actions: cannot send GPO_INTERACTION message");
+        zsys_error ("fty_alert_actions: cannot send GPO_INTERACTION message");
         return;
     }
-    void *which = zpoller_wait(self->requestreply_poller, self->requestreply_timeout);
+    void *which = zpoller_wait (self->requestreply_poller, self->requestreply_timeout);
     if (which == NULL) {
-        zsys_error("fty_alert_actions: received no reply on GPO_INTERACTION message");
+        zsys_error ("fty_alert_actions: received no reply on GPO_INTERACTION message");
     } else {
-        zmsg_t *reply_msg = mlm_client_recv(self->requestreply_client);
-        char *zuuid_str = zmsg_popstr(reply_msg);
-        if (streq(zuuid_str, zuuid_str_canonical(zuuid))) {
-            char *cmd = zmsg_popstr(reply_msg);
+        zmsg_t *reply_msg = mlm_client_recv (self->requestreply_client);
+        char *zuuid_str = zmsg_popstr (reply_msg);
+        if (streq (zuuid_str, zuuid_str_canonical (zuuid))) {
+            char *cmd = zmsg_popstr (reply_msg);
             if (0 == strcmp(cmd, "OK")) {
-                zsys_debug("fty_alert_actions: GPO_INTERACTION successful");
-            } else {
-                char *cause = zmsg_popstr(reply_msg);
-                zsys_error("fty_alert_actions: GPO_INTERACTION failed due to %s", cause);
+                zsys_debug ("fty_alert_actions: GPO_INTERACTION successful");
+            }
+            else {
+                char *cause = zmsg_popstr (reply_msg);
+                zsys_error ("fty_alert_actions: GPO_INTERACTION failed due to %s", cause);
                 zstr_free(&cause);
             }
             zstr_free(&cmd);
-        } else
-            zsys_error("fty_alert_actions: received invalid reply on GPO_INTERACTION message");
-        zstr_free(&zuuid_str);
-        zmsg_destroy(&reply_msg);
+        }
+        else
+            zsys_error ("fty_alert_actions: received invalid reply on GPO_INTERACTION message");
+        zstr_free (&zuuid_str);
+        zmsg_destroy (&reply_msg);
     }
-    zuuid_destroy(&zuuid);
+    zuuid_destroy (&zuuid);
 }
 
 
@@ -445,11 +454,12 @@ send_gpo_action(fty_alert_actions_t *self, char *gpo_iname, char *gpo_state) {
 //  Emails, smses and gpos are handled here
 
 void
-action_alert(fty_alert_actions_t *self, s_alert_cache *alert_item) {
+action_alert(fty_alert_actions_t *self, s_alert_cache *alert_item)
+{
     zsys_debug("fty_alert_actions: action_alert called for %s", fty_proto_name(alert_item->alert_msg));
     const char *action = (const char *) fty_proto_action_first(alert_item->alert_msg);
     while (NULL != action) {
-        zsys_debug("action = %s", action);
+        zsys_debug ("action = %s", action);
         char *action_dup = strdup(action);
         char *action_what = strtok(action_dup, ":");
         if (NULL == action_what) {
@@ -459,19 +469,21 @@ action_alert(fty_alert_actions_t *self, s_alert_cache *alert_item) {
             continue;
         }
         char *tmp = strtok(NULL, ":");
-        if (streq(action_what, EMAIL_ACTION)) {
+        if (streq (action_what, EMAIL_ACTION)) {
             if (NULL == tmp) { // sanity check
                 send_email(self, alert_item, EMAIL_ACTION_VALUE);
             } else {
                 zsys_warning("fty_alert_actions: unexpected parameter received for email action");
             }
-        } else if (streq(action_what, SMS_ACTION)) {
+        }
+        else if (streq (action_what, SMS_ACTION)) {
             if (NULL == tmp) { // sanity check
                 send_email(self, alert_item, SMS_ACTION_VALUE);
             } else {
                 zsys_warning("fty_alert_actions: unexpected parameter received for sms action");
             }
-        } else if (streq(action_what, GPO_ACTION)) {
+        }
+        else if (streq (action_what, GPO_ACTION)) {
             char *gpo_iname = tmp; // asset iname
             if (NULL == gpo_iname) {
                 zsys_warning("fty_alert_actions: GPO_ACTION miss asset iname");
@@ -492,7 +504,8 @@ action_alert(fty_alert_actions_t *self, s_alert_cache *alert_item) {
             } else {
                 zsys_warning("fty_alert_actions: unexpected parameter received for gpo_interaction action");
             }
-        } else {
+        }
+        else {
             zsys_warning("fty_alert_actions: unsupported alert action");
         }
         free(action_dup);
@@ -506,7 +519,8 @@ action_alert(fty_alert_actions_t *self, s_alert_cache *alert_item) {
 //  Only emails and smses are handled here
 
 void
-action_alert_repeat(fty_alert_actions_t *self, s_alert_cache *alert_item) {
+action_alert_repeat(fty_alert_actions_t *self, s_alert_cache *alert_item)
+{
     zsys_debug("fty_alert_actions: action_alert_repeat called for %s", fty_proto_name(alert_item->alert_msg));
     if (streq (fty_proto_state (alert_item->alert_msg), "ACK-PAUSE") ||
             streq (fty_proto_state (alert_item->alert_msg), "ACK-IGNORE") ||
@@ -525,21 +539,24 @@ action_alert_repeat(fty_alert_actions_t *self, s_alert_cache *alert_item) {
             continue;
         }
         char *tmp = strtok(NULL, ":");
-        if (streq(action_what, EMAIL_ACTION)) {
+        if (streq (action_what, EMAIL_ACTION)) {
             if (NULL == tmp) { // sanity check
                 send_email(self, alert_item, EMAIL_ACTION_VALUE);
             } else {
                 zsys_warning("fty_alert_actions: unexpected parameter received for email action");
             }
-        } else if (streq(action_what, SMS_ACTION)) {
+        }
+        else if (streq (action_what, SMS_ACTION)) {
             if (NULL == tmp) { // sanity check
                 send_email(self, alert_item, SMS_ACTION_VALUE);
             } else {
                 zsys_warning("fty_alert_actions: unexpected parameter received for sms action");
             }
-        } else if (streq(action_what, GPO_ACTION)) {
+        }
+        else if (streq (action_what, GPO_ACTION)) {
             // happily ignored
-        } else {
+        }
+        else {
             zsys_warning("fty_alert_actions: unsupported alert action");
         }
         free(action_dup);
@@ -553,7 +570,8 @@ action_alert_repeat(fty_alert_actions_t *self, s_alert_cache *alert_item) {
 //  Only gpos are handled here
 
 void
-action_resolve(fty_alert_actions_t *self, s_alert_cache *alert_item) {
+action_resolve(fty_alert_actions_t *self, s_alert_cache *alert_item)
+{
     zsys_debug("fty_alert_actions: action_resolve called for %s", fty_proto_name(alert_item->alert_msg));
     const char *action = (const char *) fty_proto_action_first(alert_item->alert_msg);
     while (NULL != action) {
@@ -566,11 +584,13 @@ action_resolve(fty_alert_actions_t *self, s_alert_cache *alert_item) {
             continue;
         }
         char *tmp = strtok(NULL, ":");
-        if (streq(action_what, EMAIL_ACTION)) {
+        if (streq (action_what, EMAIL_ACTION)) {
             // happily ignored
-        } else if (streq(action_what, SMS_ACTION)) {
+        }
+        else if (streq (action_what, SMS_ACTION)) {
             // happily ignored
-        } else if (streq(action_what, GPO_ACTION)) {
+        }
+        else if (streq (action_what, GPO_ACTION)) {
             char *gpo_iname = tmp; // asset iname
             if (NULL == gpo_iname) {
                 zsys_warning("fty_alert_actions: GPO_ACTION miss asset iname");
@@ -597,7 +617,8 @@ action_resolve(fty_alert_actions_t *self, s_alert_cache *alert_item) {
             } else {
                 zsys_warning("fty_alert_actions: unexpected parameter received for gpo_interaction action");
             }
-        } else {
+        }
+        else {
             zsys_warning("fty_alert_actions: unsupported alert action");
         }
         free(action_dup);
@@ -610,9 +631,10 @@ action_resolve(fty_alert_actions_t *self, s_alert_cache *alert_item) {
 //  Check for timed out alerts, resolve them and delete them
 
 void
-check_timed_out_alerts(fty_alert_actions_t *self) {
+check_timed_out_alerts(fty_alert_actions_t *self)
+{
     s_alert_cache *it = (s_alert_cache *) zhash_first(self->alerts_cache);
-    uint64_t now = zclock_mono();
+    uint64_t now = zclock_mono ();
     while (NULL != it) {
         if (it->last_received + (fty_proto_ttl(it->alert_msg) * 1000) < now) {
             zsys_debug("fty_alert_actions: found timed out alert from %s", fty_proto_name(it->alert_msg));
@@ -628,9 +650,10 @@ check_timed_out_alerts(fty_alert_actions_t *self) {
 //  Resend alerts periodically based on times table - severity and priority
 
 void
-check_alerts_and_send_if_needed(fty_alert_actions_t *self) {
+check_alerts_and_send_if_needed(fty_alert_actions_t *self)
+{
     s_alert_cache *it = (s_alert_cache *) zhash_first(self->alerts_cache);
-    uint64_t now = zclock_mono();
+    uint64_t now = zclock_mono ();
     while (NULL != it) {
         uint64_t notification_delay = get_alert_interval(it, self->notification_override);
         if (0 != notification_delay && (it->last_notification + notification_delay < now)) {
@@ -646,46 +669,48 @@ check_alerts_and_send_if_needed(fty_alert_actions_t *self) {
 //  Handle incoming alerts through stream
 
 static void
-s_handle_stream_deliver_alert(fty_alert_actions_t *self, fty_proto_t **alert_p, const char *subject) {
-    assert(self);
-    assert(alert_p);
-    assert(subject);
+s_handle_stream_deliver_alert (fty_alert_actions_t *self, fty_proto_t **alert_p, const char *subject)
+{
+    assert (self);
+    assert (alert_p);
+    assert (subject);
     fty_proto_t *alert = *alert_p;
-    if (!alert || fty_proto_id(alert) != FTY_PROTO_ALERT) {
+    if (!alert || fty_proto_id (alert) != FTY_PROTO_ALERT) {
         if (alert)
-            fty_proto_destroy(&alert);
-        zsys_warning("fty_alert_actions: Message not FTY_PROTO_ALERT.");
+            fty_proto_destroy (&alert);
+        zsys_warning ("fty_alert_actions: Message not FTY_PROTO_ALERT.");
         return;
     }
     s_alert_cache *search;
-    const char *rule = fty_proto_rule(alert);
+    const char *rule = fty_proto_rule (alert);
     search = (s_alert_cache *) zhash_lookup(self->alerts_cache, rule);
-    if (streq(fty_proto_state(alert), "ACTIVE") || streq(fty_proto_state(alert), "ACK-WIP") ||
-            streq(fty_proto_state(alert), "ACK-PAUSE") || streq(fty_proto_state(alert), "ACK-IGNORE") ||
-            streq(fty_proto_state(alert), "ACK-SILENCE")) {
-        zsys_debug("fty_alert_actions: receieved %s alarm with subject %s", fty_proto_state(alert), subject);
+    if (streq (fty_proto_state (alert), "ACTIVE") || streq (fty_proto_state (alert), "ACK-WIP") ||
+            streq (fty_proto_state (alert), "ACK-PAUSE") || streq (fty_proto_state (alert), "ACK-IGNORE") ||
+            streq (fty_proto_state (alert), "ACK-SILENCE")) {
+        zsys_debug("fty_alert_actions: receieved %s alarm with subject %s", fty_proto_state (alert), subject);
         if (NULL == search) {
             // create new alert object in cache
             zsys_debug("fty_alert_actions: new alarm, add it to database");
-            search = new_alert_cache_item(self, alert);
+            search = new_alert_cache_item (self, alert);
             if (NULL == search) {
-                fty_proto_destroy(alert_p);
+                fty_proto_destroy (alert_p);
                 return;
             }
-            zhash_insert(self->alerts_cache, rule, search);
-            zhash_freefn(self->alerts_cache, rule, delete_alert_cache_item);
+            zhash_insert (self->alerts_cache, rule, search);
+            zhash_freefn (self->alerts_cache, rule, delete_alert_cache_item);
             action_alert(self, search);
         } else {
             zsys_debug("fty_alert_actions: known alarm, check for changes");
             search->last_received = zclock_mono();
             char changed = 0;
             // little more complicated, update cache, alert on changes
-            if (streq(fty_proto_state(search->alert_msg), "ACTIVE") &&
-                    (streq(fty_proto_state(alert), "ACK-WIP") ||
-                    streq(fty_proto_state(alert), "ACK-PAUSE") ||
-                    streq(fty_proto_state(alert), "ACK-IGNORE") ||
-                    streq(fty_proto_state(alert), "ACK-SILENCE"))) {
-                changed = 1;
+            if (streq (fty_proto_state (search->alert_msg), "ACTIVE") &&
+                (streq (fty_proto_state (alert), "ACK-WIP") ||
+                 streq (fty_proto_state (alert), "ACK-PAUSE") ||
+                 streq (fty_proto_state (alert), "ACK-IGNORE") ||
+                 streq (fty_proto_state (alert), "ACK-SILENCE")))
+            {
+                    changed = 1;
             }
             if (!streq(fty_proto_severity(search->alert_msg), fty_proto_severity(alert)) ||
                     !streq(fty_proto_description(search->alert_msg), fty_proto_description(alert))) {
@@ -704,7 +729,7 @@ s_handle_stream_deliver_alert(fty_alert_actions_t *self, fty_proto_t **alert_p, 
             if (NULL != action1 || NULL != action2) {
                 changed = 1;
             }
-            zsys_debug("changed = %d", changed);
+            zsys_debug ("changed = %d", changed);
             if (1 == changed) {
                 // simple workaround to handle alerts for assets changed during alert being active
                 zsys_debug("fty_alert_actions: known alarm resolved as updated, resolving previous alert");
@@ -717,7 +742,8 @@ s_handle_stream_deliver_alert(fty_alert_actions_t *self, fty_proto_t **alert_p, 
                 action_alert(self, search);
             }
         }
-    } else if (streq(fty_proto_state(alert), "RESOLVED")) {
+    }
+    else if (streq (fty_proto_state (alert), "RESOLVED")) {
         zsys_debug("fty_alert_actions: receieved RESOLVED alarm with subject %s", subject);
         if (NULL != search) {
             search->last_received = zclock_mono();
@@ -726,10 +752,11 @@ s_handle_stream_deliver_alert(fty_alert_actions_t *self, fty_proto_t **alert_p, 
             zhash_delete(self->alerts_cache, rule);
         }
         // we don't care about alerts that are resolved and not stored - were never active
-        fty_proto_destroy(alert_p);
-    } else {
-        fty_proto_destroy(alert_p);
-        zsys_warning("fty_alert_actions: Message state not ACTIVE or RESOLVED. Skipping it.");
+        fty_proto_destroy (alert_p);
+    }
+    else {
+        fty_proto_destroy (alert_p);
+        zsys_warning ("fty_alert_actions: Message state not ACTIVE or RESOLVED. Skipping it.");
     }
     return;
 }
@@ -739,23 +766,24 @@ s_handle_stream_deliver_alert(fty_alert_actions_t *self, fty_proto_t **alert_p, 
 //  Handle incoming assets through stream
 
 static void
-s_handle_stream_deliver_asset(fty_alert_actions_t *self, fty_proto_t **asset_p, const char *subject) {
-    assert(self);
-    assert(asset_p);
-    assert(subject);
+s_handle_stream_deliver_asset(fty_alert_actions_t *self, fty_proto_t **asset_p, const char *subject)
+{
+    assert (self);
+    assert (asset_p);
+    assert (subject);
     fty_proto_t *asset = *asset_p;
-    if (!asset || fty_proto_id(asset) != FTY_PROTO_ASSET) {
+    if (!asset || fty_proto_id (asset) != FTY_PROTO_ASSET) {
         if (asset)
-            fty_proto_destroy(&asset);
-        zsys_warning("fty_alert_actions: Message not FTY_PROTO_ASSET.");
+            fty_proto_destroy (&asset);
+        zsys_warning ("fty_alert_actions: Message not FTY_PROTO_ASSET.");
         return;
     }
-    const char *operation = fty_proto_operation(asset);
-    const char *assetname = fty_proto_name(asset);
+    const char *operation = fty_proto_operation (asset);
+    const char *assetname = fty_proto_name (asset);
 
-    if (streq(operation, "delete")) {
+    if (streq (operation, "delete")) {
         zsys_debug("fty_alert_actions: received delete for asset %s", assetname);
-        fty_proto_t *item = (fty_proto_t *) zhash_lookup(self->assets_cache, assetname);
+        fty_proto_t *item = (fty_proto_t *)zhash_lookup (self->assets_cache, assetname);
         if (NULL != item) {
             s_alert_cache *it = (s_alert_cache *) zhash_first(self->alerts_cache);
             if (NULL != it)
@@ -768,21 +796,22 @@ s_handle_stream_deliver_asset(fty_alert_actions_t *self, fty_proto_t **asset_p, 
                 }
                 it = (s_alert_cache *) zhash_next(self->alerts_cache);
             }
-            zhash_delete(self->assets_cache, assetname);
+            zhash_delete (self->assets_cache, assetname);
         }
-        fty_proto_destroy(asset_p);
-    } else if (streq(operation, "update")) {
+        fty_proto_destroy (asset_p);
+    }
+    else if (streq (operation, "update")) {
         zsys_debug("fty_alert_actions: received update for asset %s", assetname);
         fty_proto_t *known = (fty_proto_t *) zhash_lookup(self->assets_cache, assetname);
         if (NULL != known) {
             char changed = 0;
             if (!streq(fty_proto_ext_string(known, "contact_email", ""),
-                    fty_proto_ext_string(asset, "contact_email", "")) ||
+                        fty_proto_ext_string(asset, "contact_email", "")) ||
                     !streq(fty_proto_ext_string(known, "contact_phone", ""),
-                    fty_proto_ext_string(asset, "contact_phone", ""))) {
+                        fty_proto_ext_string(asset, "contact_phone", ""))) {
                 changed = 1;
             }
-            zsys_debug("changed = %d", changed);
+            zsys_debug ("changed = %d", changed);
             if (1 == changed) {
                 // simple workaround to handle alerts for assets changed during alert being active
                 zsys_debug("fty_alert_actions: known asset was updated, resolving previous alert");
@@ -801,7 +830,7 @@ s_handle_stream_deliver_asset(fty_alert_actions_t *self, fty_proto_t **asset_p, 
             zhash_t *tmp_aux = fty_proto_get_aux(asset);
             fty_proto_set_ext(known, &tmp_ext);
             fty_proto_set_aux(known, &tmp_aux);
-            assetname = fty_proto_name(known);
+            assetname = fty_proto_name (known);
             fty_proto_destroy(asset_p);
             if (1 == changed) {
                 zsys_debug("fty_alert_actions: known asset was updated, sending notifications");
@@ -820,11 +849,12 @@ s_handle_stream_deliver_asset(fty_alert_actions_t *self, fty_proto_t **asset_p, 
             zhash_insert(self->assets_cache, assetname, asset);
             zhash_freefn(self->assets_cache, assetname, fty_proto_destroy_wrapper);
         }
-    } else {
+    }
+    else {
         // 'create' is skipped because each is followed by an 'update'
         // 'inventory' is skipped because it does not contain any info we need
         zsys_debug("fty_alert_actions: not an update or delete operation for this message");
-        fty_proto_destroy(asset_p);
+        fty_proto_destroy (asset_p);
     }
 }
 
@@ -833,17 +863,20 @@ s_handle_stream_deliver_asset(fty_alert_actions_t *self, fty_proto_t **asset_p, 
 //  Handle incoming alerts through stream
 
 static void
-s_handle_stream_deliver(fty_alert_actions_t *self, zmsg_t** msg_p, const char *subject) {
-    assert(self);
-    assert(msg_p);
-    fty_proto_t *proto_msg = fty_proto_decode(msg_p);
-    if (NULL != proto_msg && fty_proto_id(proto_msg) == FTY_PROTO_ALERT) {
+s_handle_stream_deliver(fty_alert_actions_t *self, zmsg_t** msg_p, const char *subject)
+{
+    assert (self);
+    assert (msg_p);
+    fty_proto_t *proto_msg = fty_proto_decode (msg_p);
+    if (NULL != proto_msg && fty_proto_id (proto_msg) == FTY_PROTO_ALERT) {
         s_handle_stream_deliver_alert(self, &proto_msg, subject);
-    } else if (NULL != proto_msg && fty_proto_id(proto_msg) == FTY_PROTO_ASSET) {
+    }
+    else if (NULL != proto_msg && fty_proto_id (proto_msg) == FTY_PROTO_ASSET) {
         s_handle_stream_deliver_asset(self, &proto_msg, subject);
-    } else {
-        zsys_warning("fty_alert_actions: Message not FTY_PROTO_ALERT nor FTY_PROTO_ASSET, ignoring.");
-        fty_proto_destroy(&proto_msg);
+    }
+    else {
+        zsys_warning ("fty_alert_actions: Message not FTY_PROTO_ALERT nor FTY_PROTO_ASSET, ignoring.");
+        fty_proto_destroy (&proto_msg);
     }
     return;
 }
@@ -853,53 +886,60 @@ s_handle_stream_deliver(fty_alert_actions_t *self, zmsg_t** msg_p, const char *s
 //  Handle incoming alerts through pipe
 
 static int
-s_handle_pipe_deliver(fty_alert_actions_t *self, zmsg_t** msg_p, uint64_t &timeout) {
+s_handle_pipe_deliver(fty_alert_actions_t *self, zmsg_t** msg_p, uint64_t &timeout)
+{
     zmsg_t *msg = *msg_p;
-    char *cmd = zmsg_popstr(msg);
+    char *cmd = zmsg_popstr (msg);
 
     zsys_debug("fty_alert_actions: %s received", cmd);
 
-    if (streq(cmd, "$TERM")) {
-        zstr_free(&cmd);
-        zmsg_destroy(&msg);
+    if (streq (cmd, "$TERM")) {
+        zstr_free (&cmd);
+        zmsg_destroy (&msg);
         return -1;
-    } else if (streq(cmd, "VERBOSE")) {
-        verbose = 1;
-    } else if (streq(cmd, "CONNECT")) {
-        char* endpoint = zmsg_popstr(msg);
-        int rv = mlm_client_connect(self->client, endpoint, 1000, self->name);
-        if (rv == -1)
-            zsys_error("fty_alert_actions: can't connect to malamute endpoint '%s'", endpoint);
-        rv = mlm_client_connect(self->requestreply_client, endpoint, 1000, self->requestreply_name);
-        if (rv == -1)
-            zsys_error("fty_alert_actions: can't connect requestreply to malamute endpoint '%s'", endpoint);
-        zstr_free(&endpoint);
-    } else if (streq(cmd, "CONSUMER")) {
-        char* stream = zmsg_popstr(msg);
-        self->integration_test = streq(stream, TEST_ALERTS) || streq(stream, TEST_ASSETS);
-        char* pattern = zmsg_popstr(msg);
-        int rv = mlm_client_set_consumer(self->client, stream, pattern);
-        if (rv == -1)
-            zsys_error("fty_alert_actions: can't set consumer on stream '%s', '%s'", stream, pattern);
-        zstr_free(&pattern);
-        zstr_free(&stream);
-    } else if (streq(cmd, "ASKFORASSETS")) {
-        zmsg_t *republish = zmsg_new();
-        int rv = mlm_client_sendto(self->client, FTY_ASSET_AGENT_ADDRESS, "REPUBLISH", NULL, 5000, &republish);
-        if (rv != 0) {
-            zsys_error("fty_alert_actions: can't send REPUBLISH message");
-        }
-    } else if (streq(cmd, "TESTTIMEOUT")) {
-        char *rcvd = zmsg_popstr(msg);
-        sscanf(rcvd, "%" SCNu64, &timeout);
-        zstr_free(&rcvd);
-    } else if (streq(cmd, "TESTCHECKINTERVAL")) {
-        char *rcvd = zmsg_popstr(msg);
-        sscanf(rcvd, "%" SCNu64, &(self->notification_override));
-        zstr_free(&rcvd);
     }
-    zstr_free(&cmd);
-    zmsg_destroy(&msg);
+    else if (streq (cmd, "VERBOSE")) {
+        verbose = 1;
+    }
+    else if (streq (cmd, "CONNECT")) {
+        char* endpoint = zmsg_popstr (msg);
+        int rv = mlm_client_connect (self->client, endpoint, 1000, self->name);
+        if (rv == -1)
+            zsys_error ("fty_alert_actions: can't connect to malamute endpoint '%s'", endpoint);
+        rv = mlm_client_connect (self->requestreply_client, endpoint, 1000, self->requestreply_name);
+        if (rv == -1)
+            zsys_error ("fty_alert_actions: can't connect requestreply to malamute endpoint '%s'", endpoint);
+        zstr_free (&endpoint);
+    }
+    else if (streq (cmd, "CONSUMER")) {
+        char* stream = zmsg_popstr (msg);
+        self->integration_test = streq (stream, TEST_ALERTS) || streq (stream, TEST_ASSETS);
+        char* pattern = zmsg_popstr (msg);
+        int rv = mlm_client_set_consumer (self->client, stream, pattern);
+        if (rv == -1)
+            zsys_error ("fty_alert_actions: can't set consumer on stream '%s', '%s'", stream, pattern);
+        zstr_free (&pattern);
+        zstr_free (&stream);
+    }
+    else if (streq (cmd, "ASKFORASSETS")) {
+        zmsg_t *republish = zmsg_new ();
+        int rv = mlm_client_sendto (self->client, FTY_ASSET_AGENT_ADDRESS, "REPUBLISH", NULL, 5000, &republish);
+        if (rv != 0) {
+            zsys_error ("fty_alert_actions: can't send REPUBLISH message");
+        }
+    }
+    else if (streq (cmd, "TESTTIMEOUT")) {
+        char *rcvd = zmsg_popstr (msg);
+        sscanf(rcvd, "%" SCNu64, &timeout);
+        zstr_free (&rcvd);
+    }
+    else if (streq (cmd, "TESTCHECKINTERVAL")) {
+        char *rcvd = zmsg_popstr (msg);
+        sscanf(rcvd, "%" SCNu64, &(self->notification_override));
+        zstr_free (&rcvd);
+    }
+    zstr_free (&cmd);
+    zmsg_destroy (&msg);
     return 0;
 }
 
@@ -908,8 +948,9 @@ s_handle_pipe_deliver(fty_alert_actions_t *self, zmsg_t** msg_p, uint64_t &timeo
 //  fty_alert_actions actor function
 
 void
-fty_alert_actions(zsock_t *pipe, void* args) {
-    fty_alert_actions_t *self = fty_alert_actions_new();
+fty_alert_actions(zsock_t *pipe, void* args)
+{
+    fty_alert_actions_t *self = fty_alert_actions_new ();
     assert(self);
     self->name = (char*) args;
     self->requestreply_name = zsys_sprintf("%s#mb", self->name);
@@ -931,39 +972,39 @@ fty_alert_actions(zsock_t *pipe, void* args) {
             check_alerts_and_send_if_needed(self);
         }
         if (which == NULL) {
-            if (zpoller_terminated(poller) || zsys_interrupted) {
-                zsys_warning("fty_alert_actions: zpoller_terminated () or zsys_interrupted. Shutting down.");
+            if (zpoller_terminated (poller) || zsys_interrupted) {
+                zsys_warning ("fty_alert_actions: zpoller_terminated () or zsys_interrupted. Shutting down.");
                 break;
             }
-            if (zpoller_expired(poller) && !self->integration_test) {
+            if (zpoller_expired (poller) && !self->integration_test) {
                 zsys_debug("fty_alert_actions: poller timeout expired");
             }
             continue;
         }
         // pipe messages
         if (which == pipe) {
-            msg = zmsg_recv(pipe);
+            msg = zmsg_recv (pipe);
             if (0 == s_handle_pipe_deliver(self, &msg, timeout)) {
                 continue;
             } else {
                 break;
             }
         }
-        msg = mlm_client_recv(self->client);
+        msg = mlm_client_recv (self->client);
         // stream messages - receieve ASSETS and ALERTS
-        if (is_fty_proto(msg)) {
-            s_handle_stream_deliver(self, &msg, mlm_client_subject(self->client));
+        if (is_fty_proto (msg)) {
+            s_handle_stream_deliver (self, &msg, mlm_client_subject (self->client));
             continue;
         }
         // all other messages should be ignored
-        zsys_debug("fty_alert_actions: received message through '%s' from '%s' with subject '%s' that is ignored",
-                mlm_client_address(self->client),
-                mlm_client_sender(self->client),
-                mlm_client_subject(self->client));
-        zmsg_destroy(&msg);
+        zsys_debug ("fty_alert_actions: received message through '%s' from '%s' with subject '%s' that is ignored",
+                mlm_client_address (self->client),
+                mlm_client_sender (self->client),
+                mlm_client_subject (self->client));
+        zmsg_destroy (&msg);
     }
-    zpoller_destroy(&poller);
-    fty_alert_actions_destroy(&self);
+    zpoller_destroy (&poller);
+    fty_alert_actions_destroy (&self);
 }
 
 
@@ -984,19 +1025,21 @@ fty_alert_actions(zsock_t *pipe, void* args) {
 #define SELFTEST_DIR_RW "src/selftest-rw"
 
 void
-fty_alert_actions_test(bool verbose) {
-    printf(" * fty_alert_actions: ");
+fty_alert_actions_test (bool verbose)
+{
+    printf (" * fty_alert_actions: ");
     testing = 1;
-    SET_SUBJECT((char *) "testing");
+    SET_SUBJECT((char *)"testing");
 
     //  @selftest
     // test 1, simple create/destroy self test
     {
         zsys_debug("fty_alert_actions: test 1");
-        fty_alert_actions_t *self = fty_alert_actions_new();
-        assert(self);
-        fty_alert_actions_destroy(&self);
+        fty_alert_actions_t *self = fty_alert_actions_new ();
+        assert (self);
+        fty_alert_actions_destroy (&self);
     }
+
     // test 2, check alert interval calculation
     {
         zsys_debug("fty_alert_actions: test 2");
@@ -1044,16 +1087,17 @@ fty_alert_actions_test(bool verbose) {
         fty_proto_destroy(&cache->related_asset);
         free(cache);
     }
+
     // test 3, simple create/destroy cache item test without need to send ASSET_DETAILS
     {
         zsys_debug("fty_alert_actions: test 3");
-        fty_alert_actions_t *self = fty_alert_actions_new();
-        assert(self);
+        fty_alert_actions_t *self = fty_alert_actions_new ();
+        assert (self);
         fty_proto_t *asset = fty_proto_new(FTY_PROTO_ASSET);
-        assert(asset);
+        assert (asset);
         zhash_insert(self->assets_cache, "myasset-3", asset);
         fty_proto_t *msg = fty_proto_new(FTY_PROTO_ALERT);
-        assert(msg);
+        assert (msg);
         fty_proto_set_name(msg, "myasset-3");
 
         s_alert_cache *cache = new_alert_cache_item(self, msg);
@@ -1061,8 +1105,9 @@ fty_alert_actions_test(bool verbose) {
         delete_alert_cache_item(cache);
 
         fty_proto_destroy(&asset);
-        fty_alert_actions_destroy(&self);
+        fty_alert_actions_destroy (&self);
     }
+
     // test 4, simple create/destroy cache item test with need to send ASSET_DETAILS
     {
         zsys_debug("fty_alert_actions: test 4");
@@ -1075,17 +1120,17 @@ fty_alert_actions_test(bool verbose) {
         INIT_RECV;
         MSG_TO_RECV(resp_msg);
         SET_SEND(0);
-        fty_alert_actions_t *self = fty_alert_actions_new();
-        assert(self);
+        fty_alert_actions_t *self = fty_alert_actions_new ();
+        assert (self);
         fty_proto_t *msg = fty_proto_new(FTY_PROTO_ALERT);
-        assert(msg);
+        assert (msg);
         fty_proto_set_name(msg, "myasset-4");
 
         s_alert_cache *cache = new_alert_cache_item(self, msg);
         assert(cache);
         delete_alert_cache_item(cache);
 
-        fty_alert_actions_destroy(&self);
+        fty_alert_actions_destroy (&self);
         zhash_destroy(&aux);
         zhash_destroy(&ext);
         CLEAN_RECV;
@@ -1094,7 +1139,7 @@ fty_alert_actions_test(bool verbose) {
     // test 5, processing of alerts from stream
     {
         zsys_debug("fty_alert_actions: test 5");
-        SET_UUID((char *) "uuid-test");
+        SET_UUID((char *)"uuid-test");
         zhash_t *aux = zhash_new();
         zhash_t *ext = zhash_new();
         zmsg_t *resp_msg = fty_proto_encode_asset(aux, "SOME_ASSET", FTY_PROTO_ASSET_OP_UPDATE, ext);
@@ -1104,65 +1149,65 @@ fty_alert_actions_test(bool verbose) {
         MSG_TO_RECV(resp_msg);
         SET_SEND(0);
 
-        fty_alert_actions_t *self = fty_alert_actions_new();
-        assert(self);
+        fty_alert_actions_t *self = fty_alert_actions_new ();
+        assert (self);
 
-        zlist_t *actions = zlist_new();
-        zlist_autofree(actions);
-        zlist_append(actions, (void *) "SMS");
-        zlist_append(actions, (void *) "EMAIL");
+        zlist_t *actions = zlist_new ();
+        zlist_autofree (actions);
+        zlist_append (actions, (void *) "SMS");
+        zlist_append (actions, (void *) "EMAIL");
         zmsg_t *msg = fty_proto_encode_alert
-                (NULL,
-                ::time(NULL),
-                600,
-                "SOME_RULE",
-                "SOME_ASSET",
-                "ACTIVE",
-                "CRITICAL",
-                "ASDFKLHJH",
-                actions);
-        assert(msg);
+                        (NULL,
+                         ::time (NULL),
+                         600,
+                         "SOME_RULE",
+                         "SOME_ASSET",
+                         "ACTIVE",
+                         "CRITICAL",
+                         "ASDFKLHJH",
+                         actions);
+        assert (msg);
 
         // send an active alert
-        s_handle_stream_deliver(self, &msg, "");
-        zlist_destroy(&actions);
-        zclock_sleep(1000);
+        s_handle_stream_deliver (self, &msg, "");
+        zlist_destroy (&actions);
+        zclock_sleep (1000);
 
         // check the alert cache
-        assert(zhash_size(self->alerts_cache) == 1);
-        s_alert_cache *cached = (s_alert_cache *) zhash_first(self->alerts_cache);
+        assert ( zhash_size (self->alerts_cache) == 1 );
+        s_alert_cache *cached =  (s_alert_cache *) zhash_first (self->alerts_cache);
         fty_proto_t *alert = cached->alert_msg;
-        assert(streq(fty_proto_rule(alert), "SOME_RULE"));
-        assert(streq(fty_proto_name(alert), "SOME_ASSET"));
-        assert(streq(fty_proto_state(alert), "ACTIVE"));
-        assert(streq(fty_proto_severity(alert), "CRITICAL"));
-        assert(streq(fty_proto_description(alert), "ASDFKLHJH"));
-        assert(streq(fty_proto_action_first(alert), "SMS"));
-        assert(streq(fty_proto_action_next(alert), "EMAIL"));
+        assert ( streq (fty_proto_rule (alert), "SOME_RULE") );
+        assert ( streq (fty_proto_name (alert), "SOME_ASSET") );
+        assert ( streq (fty_proto_state (alert), "ACTIVE") );
+        assert ( streq (fty_proto_severity (alert), "CRITICAL") );
+        assert ( streq (fty_proto_description (alert), "ASDFKLHJH") );
+        assert ( streq (fty_proto_action_first (alert), "SMS") );
+        assert ( streq (fty_proto_action_next (alert), "EMAIL") );
 
         // resolve the alert
-        actions = zlist_new();
-        zlist_autofree(actions);
+        actions = zlist_new ();
+        zlist_autofree (actions);
         msg = fty_proto_encode_alert
-                (NULL,
-                ::time(NULL),
-                600,
-                "SOME_RULE",
-                "SOME_ASSET",
-                "RESOLVED",
-                "CRITICAL",
-                "ASDFKLHJH",
-                actions);
-        assert(msg);
+                        (NULL,
+                         ::time (NULL),
+                         600,
+                         "SOME_RULE",
+                         "SOME_ASSET",
+                         "RESOLVED",
+                         "CRITICAL",
+                         "ASDFKLHJH",
+                         actions);
+        assert (msg);
 
-        s_handle_stream_deliver(self, &msg, "");
-        zlist_destroy(&actions);
-        zclock_sleep(1000);
+        s_handle_stream_deliver (self, &msg, "");
+        zlist_destroy (&actions);
+        zclock_sleep (1000);
 
         // alert cache is now empty
-        assert(zhash_size(self->alerts_cache) == 0);
+        assert ( zhash_size (self->alerts_cache) == 0 );
         // clean up after
-        fty_alert_actions_destroy(&self);
+        fty_alert_actions_destroy (&self);
         zhash_destroy(&aux);
         zhash_destroy(&ext);
         CLEAN_RECV;
@@ -1170,40 +1215,40 @@ fty_alert_actions_test(bool verbose) {
     // test 6, processing of assets from stream
     {
         zsys_debug("fty_alert_actions: test 6");
-        fty_alert_actions_t *self = fty_alert_actions_new();
-        assert(self);
+        fty_alert_actions_t *self = fty_alert_actions_new ();
+        assert (self);
 
         // send update
         zmsg_t *msg = fty_proto_encode_asset
-                (NULL,
-                "SOME_ASSET",
-                FTY_PROTO_ASSET_OP_UPDATE,
-                NULL);
-        assert(msg);
+                        (NULL,
+                         "SOME_ASSET",
+                         FTY_PROTO_ASSET_OP_UPDATE,
+                         NULL);
+        assert (msg);
 
-        s_handle_stream_deliver(self, &msg, "");
-        zclock_sleep(1000);
+        s_handle_stream_deliver (self, &msg, "");
+        zclock_sleep (1000);
 
         // check the assets cache
-        assert(zhash_size(self->assets_cache) == 1);
-        fty_proto_t *cached = (fty_proto_t *) zhash_first(self->assets_cache);
-        assert(streq(fty_proto_operation(cached), FTY_PROTO_ASSET_OP_UPDATE));
-        assert(streq(fty_proto_name(cached), "SOME_ASSET"));
+        assert ( zhash_size (self->assets_cache) == 1 );
+        fty_proto_t *cached =  (fty_proto_t *) zhash_first (self->assets_cache);
+        assert ( streq (fty_proto_operation (cached), FTY_PROTO_ASSET_OP_UPDATE) );
+        assert ( streq (fty_proto_name (cached), "SOME_ASSET") );
 
         // delete asset
         msg = fty_proto_encode_asset
-                (NULL,
-                "SOME_ASSET",
-                FTY_PROTO_ASSET_OP_DELETE,
-                NULL);
-        assert(msg);
+                        (NULL,
+                         "SOME_ASSET",
+                         FTY_PROTO_ASSET_OP_DELETE,
+                         NULL);
+        assert (msg);
 
         //assert ( zhash_size (self->assets_cache) != 0 );
-        s_handle_stream_deliver(self, &msg, "");
-        zclock_sleep(1000);
+        s_handle_stream_deliver (self, &msg, "");
+        zclock_sleep (1000);
 
-        assert(zhash_size(self->assets_cache) == 0);
-        fty_alert_actions_destroy(&self);
+        assert ( zhash_size (self->assets_cache) == 0 );
+        fty_alert_actions_destroy (&self);
     }
     {
         //test 7, send asset + send an alert on the already known correct asset
@@ -1211,7 +1256,7 @@ fty_alert_actions_test(bool verbose) {
 
         zsys_debug("fty_alert_actions: test 7");
         SET_UUID((char *) "uuid-test");
-        zmsg_t *resp_msg = zmsg_new();
+        zmsg_t *resp_msg = zmsg_new ();
         zmsg_addstr(resp_msg, GET_UUID);
         zmsg_addstr(resp_msg, "OK");
         assert(resp_msg);
@@ -1219,64 +1264,64 @@ fty_alert_actions_test(bool verbose) {
         MSG_TO_RECV(resp_msg);
         SET_SEND(0);
 
-        fty_alert_actions_t *self = fty_alert_actions_new();
-        assert(self);
+        fty_alert_actions_t *self = fty_alert_actions_new ();
+        assert (self);
         //      1. send asset info
         const char *asset_name = "ASSET1";
-        zhash_t *aux = zhash_new();
-        zhash_insert(aux, "priority", (void *) "1");
-        zhash_t *ext = zhash_new();
-        zhash_insert(ext, "contact_email", (void *) "scenario1.email@eaton.com");
-        zhash_insert(ext, "contact_name", (void *) "eaton Support team");
-        zhash_insert(ext, "name", (void *) asset_name);
+        zhash_t *aux = zhash_new ();
+        zhash_insert (aux, "priority", (void *) "1");
+        zhash_t *ext = zhash_new ();
+        zhash_insert (ext, "contact_email", (void *) "scenario1.email@eaton.com");
+        zhash_insert (ext, "contact_name", (void *) "eaton Support team");
+        zhash_insert (ext, "name", (void *) asset_name);
         zmsg_t *msg = fty_proto_encode_asset
-                (aux,
-                asset_name,
-                FTY_PROTO_ASSET_OP_UPDATE,
-                ext);
-        assert(msg);
-        s_handle_stream_deliver(self, &msg, "Asset message1");
+                        (aux,
+                         asset_name,
+                         FTY_PROTO_ASSET_OP_UPDATE,
+                         ext);
+        assert (msg);
+        s_handle_stream_deliver (self, &msg, "Asset message1");
         //assert (zhash_size (self->assets_cache) != 0);
-        zhash_destroy(&aux);
-        zhash_destroy(&ext);
-        zclock_sleep(1000);
+        zhash_destroy (&aux);
+        zhash_destroy (&ext);
+        zclock_sleep (1000);
 
         //      2. send alert message
-        zlist_t *actions = zlist_new();
-        zlist_autofree(actions);
-        zlist_append(actions, (void *) "EMAIL");
+        zlist_t *actions = zlist_new ();
+        zlist_autofree (actions);
+        zlist_append (actions, (void *) "EMAIL");
         msg = fty_proto_encode_alert
                 (NULL,
-                ::time(NULL),
-                600,
-                "NY_RULE",
-                asset_name,
-                "ACTIVE",
-                "CRITICAL",
-                "ASDFKLHJH",
-                actions);
-        assert(msg);
-        std::string atopic = "NY_RULE/CRITICAL@" + std::string(asset_name);
-        s_handle_stream_deliver(self, &msg, atopic.c_str());
-        zclock_sleep(1000);
+                 ::time (NULL),
+                 600,
+                 "NY_RULE",
+                 asset_name,
+                 "ACTIVE",
+                 "CRITICAL",
+                 "ASDFKLHJH",
+                 actions);
+        assert (msg);
+        std::string atopic = "NY_RULE/CRITICAL@" + std::string (asset_name);
+        s_handle_stream_deliver (self, &msg, atopic.c_str ());
+        zclock_sleep (1000);
         //assert ( zhash_size (self->assets_cache) != 0 );
-        zlist_destroy(&actions);
+        zlist_destroy (&actions);
 
         //      3. delete the asset
         msg = fty_proto_encode_asset
-                (NULL,
-                asset_name,
-                FTY_PROTO_ASSET_OP_DELETE,
-                NULL);
-        assert(msg);
+                        (NULL,
+                         asset_name,
+                         FTY_PROTO_ASSET_OP_DELETE,
+                         NULL);
+        assert (msg);
 
         //assert ( zhash_size (self->assets_cache) != 0 );
-        s_handle_stream_deliver(self, &msg, "Asset message 1");
-        zclock_sleep(1000);
+        s_handle_stream_deliver (self, &msg, "Asset message 1");
+        zclock_sleep (1000);
 
         //      4. check that alert disappeared
-        assert(zhash_size(self->alerts_cache) == 0);
-        fty_alert_actions_destroy(&self);
+        assert ( zhash_size (self->alerts_cache) == 0 );
+        fty_alert_actions_destroy (&self);
         CLEAN_RECV;
     }
     // do the rest of the tests the ugly way, since it's the least complicated option
@@ -1285,25 +1330,25 @@ fty_alert_actions_test(bool verbose) {
     const char *TEST_ENDPOINT = "inproc://fty-alert-actions-test";
     const char *FTY_ALERT_ACTIONS_TEST = "fty-alert-actions-test";
 
-    zactor_t *server = zactor_new(mlm_server, (void*) "Malamute_alert_actions_test");
-    assert(server != NULL);
-    zstr_sendx(server, "BIND", TEST_ENDPOINT, NULL);
+    zactor_t *server = zactor_new (mlm_server, (void*) "Malamute_alert_actions_test");
+    assert ( server != NULL );
+    zstr_sendx (server, "BIND", TEST_ENDPOINT, NULL);
 
-    zactor_t *alert_actions = zactor_new(fty_alert_actions, (void *) FTY_ALERT_ACTIONS_TEST);
-    zstr_sendx(alert_actions, "CONNECT", TEST_ENDPOINT, NULL);
-    zstr_sendx(alert_actions, "CONSUMER", TEST_ASSETS, ".*", NULL);
-    zstr_sendx(alert_actions, "CONSUMER", TEST_ALERTS, ".*", NULL);
+    zactor_t *alert_actions = zactor_new (fty_alert_actions, (void *) FTY_ALERT_ACTIONS_TEST);
+    zstr_sendx (alert_actions, "CONNECT", TEST_ENDPOINT, NULL);
+    zstr_sendx (alert_actions, "CONSUMER", TEST_ASSETS, ".*", NULL);
+    zstr_sendx (alert_actions, "CONSUMER", TEST_ALERTS, ".*", NULL);
 
-    mlm_client_t *asset_producer = mlm_client_new();
-    mlm_client_connect(asset_producer, TEST_ENDPOINT, 1000, "asset-producer-test");
-    mlm_client_set_producer(asset_producer, TEST_ASSETS);
+    mlm_client_t *asset_producer = mlm_client_new ();
+    mlm_client_connect (asset_producer, TEST_ENDPOINT, 1000, "asset-producer-test");
+    mlm_client_set_producer (asset_producer, TEST_ASSETS);
 
-    mlm_client_t *alert_producer = mlm_client_new();
-    mlm_client_connect(alert_producer, TEST_ENDPOINT, 1000, "alert-producer-test");
-    mlm_client_set_producer(alert_producer, TEST_ASSETS);
+    mlm_client_t *alert_producer = mlm_client_new ();
+    mlm_client_connect (alert_producer, TEST_ENDPOINT, 1000, "alert-producer-test");
+    mlm_client_set_producer (alert_producer, TEST_ASSETS);
 
-    mlm_client_t *email_client = mlm_client_new();
-    mlm_client_connect(email_client, TEST_ENDPOINT, 1000, FTY_EMAIL_AGENT_ADDRESS_TEST);
+    mlm_client_t *email_client = mlm_client_new ();
+    mlm_client_connect (email_client, TEST_ENDPOINT, 1000, FTY_EMAIL_AGENT_ADDRESS_TEST);
 
     // test 8, send asset with e-mail + send an alert on the already known correct asset (with e-mail action)
     // + check that we send SENDMAIL_ALERT message
@@ -1311,145 +1356,145 @@ fty_alert_actions_test(bool verbose) {
         zsys_debug("fty_alert_actions: test 8");
         //      1. send asset info
         const char *asset_name = "ASSET";
-        zhash_t *aux = zhash_new();
-        zhash_insert(aux, "priority", (void *) "1");
-        zhash_t *ext = zhash_new();
-        zhash_insert(ext, "contact_email", (void *) "scenario1.email@eaton.com");
-        zhash_insert(ext, "contact_name", (void *) "eaton Support team");
-        zhash_insert(ext, "name", (void *) asset_name);
+        zhash_t *aux = zhash_new ();
+        zhash_insert (aux, "priority", (void *) "1");
+        zhash_t *ext = zhash_new ();
+        zhash_insert (ext, "contact_email", (void *) "scenario1.email@eaton.com");
+        zhash_insert (ext, "contact_name", (void *) "eaton Support team");
+        zhash_insert (ext, "name", (void *) asset_name);
         zmsg_t *msg = fty_proto_encode_asset
-                (aux,
-                asset_name,
-                FTY_PROTO_ASSET_OP_UPDATE,
-                ext);
-        assert(msg);
-        mlm_client_send(asset_producer, "Asset message1", &msg);
-        zclock_sleep(1000);
-        zhash_destroy(&aux);
-        zhash_destroy(&ext);
+                        (aux,
+                         asset_name,
+                         FTY_PROTO_ASSET_OP_UPDATE,
+                         ext);
+        assert (msg);
+        mlm_client_send (asset_producer, "Asset message1", &msg);
+        zclock_sleep (1000);
+        zhash_destroy (&aux);
+        zhash_destroy (&ext);
 
         //      2. send alert message
-        zlist_t *actions = zlist_new();
-        zlist_autofree(actions);
-        zlist_append(actions, (void *) "EMAIL");
+        zlist_t *actions = zlist_new ();
+        zlist_autofree (actions);
+        zlist_append (actions, (void *) "EMAIL");
         msg = fty_proto_encode_alert
                 (NULL,
-                ::time(NULL),
-                600,
-                "NY_RULE",
-                asset_name,
-                "ACTIVE",
-                "CRITICAL",
-                "ASDFKLHJH",
-                actions);
-        assert(msg);
-        std::string atopic = "NY_RULE/CRITICAL@" + std::string(asset_name);
-        mlm_client_send(alert_producer, atopic.c_str(), &msg);
-        zclock_sleep(1000);
-        zlist_destroy(&actions);
+                 ::time (NULL),
+                 600,
+                 "NY_RULE",
+                 asset_name,
+                 "ACTIVE",
+                 "CRITICAL",
+                 "ASDFKLHJH",
+                 actions);
+        assert (msg);
+        std::string atopic = "NY_RULE/CRITICAL@" + std::string (asset_name);
+        mlm_client_send (alert_producer, atopic.c_str (), &msg);
+        zclock_sleep (1000);
+        zlist_destroy (&actions);
 
         //      3. check that we send SENDMAIL_ALERT message to the correct MB
-        msg = mlm_client_recv(email_client);
-        assert(msg);
-        assert(streq(mlm_client_subject(email_client), "SENDMAIL_ALERT"));
-        char *zuuid_str = zmsg_popstr(msg);
-        char *str = zmsg_popstr(msg);
-        assert(streq(str, "1"));
-        zstr_free(&str);
-        str = zmsg_popstr(msg);
-        assert(streq(str, asset_name));
-        zstr_free(&str);
-        str = zmsg_popstr(msg);
-        assert(streq(str, "scenario1.email@eaton.com"));
-        zstr_free(&str);
+        msg = mlm_client_recv (email_client);
+        assert (msg);
+        assert (streq (mlm_client_subject (email_client), "SENDMAIL_ALERT"));
+        char *zuuid_str = zmsg_popstr (msg);
+        char *str = zmsg_popstr (msg);
+        assert (streq (str, "1"));
+        zstr_free (&str);
+        str = zmsg_popstr (msg);
+        assert (streq (str, asset_name));
+        zstr_free (&str);
+        str = zmsg_popstr (msg);
+        assert (streq (str, "scenario1.email@eaton.com"));
+        zstr_free (&str);
 
-        fty_proto_t *alert = fty_proto_decode(&msg);
-        assert(streq(fty_proto_rule(alert), "NY_RULE"));
-        assert(streq(fty_proto_name(alert), asset_name));
-        assert(streq(fty_proto_state(alert), "ACTIVE"));
-        assert(streq(fty_proto_severity(alert), "CRITICAL"));
-        assert(streq(fty_proto_description(alert), "ASDFKLHJH"));
-        assert(streq(fty_proto_action_first(alert), "EMAIL"));
-        fty_proto_destroy(&alert);
+        fty_proto_t *alert = fty_proto_decode (&msg);
+        assert ( streq (fty_proto_rule (alert), "NY_RULE") );
+        assert ( streq (fty_proto_name (alert), asset_name) );
+        assert ( streq (fty_proto_state (alert), "ACTIVE") );
+        assert ( streq (fty_proto_severity (alert), "CRITICAL") );
+        assert ( streq (fty_proto_description (alert), "ASDFKLHJH") );
+        assert ( streq (fty_proto_action_first (alert), "EMAIL") );
+        fty_proto_destroy (&alert);
 
         //       4. send the reply to unblock the actor
-        zmsg_t *reply = zmsg_new();
-        zmsg_addstr(reply, zuuid_str);
-        zmsg_addstr(reply, "OK");
-        mlm_client_sendto(email_client, FTY_ALERT_ACTIONS_TEST, "SENDMAIL_ALERT", NULL, 1000, &reply);
+        zmsg_t *reply = zmsg_new ();
+        zmsg_addstr (reply, zuuid_str);
+        zmsg_addstr (reply, "OK");
+        mlm_client_sendto (email_client, FTY_ALERT_ACTIONS_TEST, "SENDMAIL_ALERT", NULL, 1000, &reply);
 
-        zstr_free(&zuuid_str);
+        zstr_free (&zuuid_str);
     }
 
     // test9, send asset + send an alert on the already known correct asset (with GPO action)
     // + check that we send GPO_INTERACTION message
-    mlm_client_t *gpio_client = mlm_client_new();
-    mlm_client_connect(gpio_client, TEST_ENDPOINT, 1000, FTY_SENSOR_GPIO_AGENT_ADDRESS_TEST);
+    mlm_client_t *gpio_client = mlm_client_new ();
+    mlm_client_connect (gpio_client, TEST_ENDPOINT, 1000, FTY_SENSOR_GPIO_AGENT_ADDRESS_TEST);
 
     {
         zsys_debug("fty_alert_actions: test 9");
         //      1. send asset info
         const char *asset_name1 = "GPO1";
-        zhash_t *aux = zhash_new();
-        zhash_insert(aux, "priority", (void *) "1");
-        zhash_t *ext = zhash_new();
-        zhash_insert(ext, "contact_email", (void *) "scenario1.email@eaton.com");
-        zhash_insert(ext, "contact_name", (void *) "eaton Support team");
-        zhash_insert(ext, "name", (void *) asset_name1);
+        zhash_t *aux = zhash_new ();
+        zhash_insert (aux, "priority", (void *) "1");
+        zhash_t *ext = zhash_new ();
+        zhash_insert (ext, "contact_email", (void *) "scenario1.email@eaton.com");
+        zhash_insert (ext, "contact_name", (void *) "eaton Support team");
+        zhash_insert (ext, "name", (void *) asset_name1);
         zmsg_t *msg = fty_proto_encode_asset
-                (aux,
-                asset_name1,
-                FTY_PROTO_ASSET_OP_UPDATE,
-                ext);
-        assert(msg);
-        mlm_client_send(asset_producer, "Asset message1", &msg);
-        zclock_sleep(1000);
-        zhash_destroy(&aux);
-        zhash_destroy(&ext);
+                        (aux,
+                         asset_name1,
+                         FTY_PROTO_ASSET_OP_UPDATE,
+                         ext);
+        assert (msg);
+        mlm_client_send (asset_producer, "Asset message1", &msg);
+        zclock_sleep (1000);
+        zhash_destroy (&aux);
+        zhash_destroy (&ext);
 
         //      2. send alert message
-        zlist_t *actions = zlist_new();
-        zlist_autofree(actions);
-        zlist_append(actions, (void *) "GPO_INTERACTION:gpo-1:open");
+        zlist_t *actions = zlist_new ();
+        zlist_autofree (actions);
+        zlist_append (actions, (void *) "GPO_INTERACTION:gpo-1:open");
         msg = fty_proto_encode_alert
                 (NULL,
-                ::time(NULL),
-                600,
-                "NY_RULE1",
-                asset_name1,
-                "ACTIVE",
-                "CRITICAL",
-                "ASDFKLHJH",
-                actions);
-        assert(msg);
-        std::string atopic = "NY_RULE1/CRITICAL@" + std::string(asset_name1);
-        mlm_client_send(alert_producer, atopic.c_str(), &msg);
-        zlist_destroy(&actions);
+                 ::time (NULL),
+                 600,
+                 "NY_RULE1",
+                 asset_name1,
+                 "ACTIVE",
+                 "CRITICAL",
+                 "ASDFKLHJH",
+                 actions);
+        assert (msg);
+        std::string atopic = "NY_RULE1/CRITICAL@" + std::string (asset_name1);
+        mlm_client_send (alert_producer, atopic.c_str (), &msg);
+        zlist_destroy (&actions);
 
         //      3. check that we send GPO_INTERACTION message to the correct MB
-        msg = mlm_client_recv(gpio_client);
-        assert(msg);
-        assert(streq(mlm_client_subject(gpio_client), "GPO_INTERACTION"));
-        zmsg_print(msg);
-        char *zuuid_str = zmsg_popstr(msg);
-        char *str = zmsg_popstr(msg);
-        assert(streq(str, "gpo-1"));
-        zstr_free(&str);
-        str = zmsg_popstr(msg);
-        assert(streq(str, "open"));
-        zstr_free(&str);
-        zmsg_destroy(&msg);
+        msg = mlm_client_recv (gpio_client);
+        assert (msg);
+        assert (streq (mlm_client_subject (gpio_client), "GPO_INTERACTION"));
+        zmsg_print (msg);
+        char *zuuid_str = zmsg_popstr (msg);
+        char *str = zmsg_popstr (msg);
+        assert (streq (str, "gpo-1"));
+        zstr_free (&str);
+        str = zmsg_popstr (msg);
+        assert (streq (str, "open"));
+        zstr_free (&str);
+        zmsg_destroy (&msg);
 
         //       4. send the reply to unblock the actor
-        zmsg_t *reply = zmsg_new();
-        zmsg_addstr(reply, zuuid_str);
-        zmsg_addstr(reply, "OK");
-        mlm_client_sendto(gpio_client, FTY_ALERT_ACTIONS_TEST, "GPO_INTERACTION", NULL, 1000, &reply);
+        zmsg_t *reply = zmsg_new ();
+        zmsg_addstr (reply, zuuid_str);
+        zmsg_addstr (reply, "OK");
+        mlm_client_sendto (gpio_client, FTY_ALERT_ACTIONS_TEST, "GPO_INTERACTION", NULL, 1000, &reply);
 
-        zstr_free(&zuuid_str);
+        zstr_free (&zuuid_str);
     }
 
-    mlm_client_destroy(&gpio_client);
+    mlm_client_destroy (&gpio_client);
     // skip the test for alert on unknown asset since agent behaves differently now
 
     // test 10, send asset without email + send an alert on the already known asset
@@ -1457,183 +1502,183 @@ fty_alert_actions_test(bool verbose) {
         zsys_debug("fty_alert_actions: test 10");
         //      1. send asset info
         const char *asset_name = "ASSET2";
-        zhash_t *aux = zhash_new();
-        zhash_insert(aux, "priority", (void *) "1");
-        zhash_t *ext = zhash_new();
-        zhash_insert(ext, "contact_name", (void *) "eaton Support team");
-        zhash_insert(ext, "name", (void *) asset_name);
-        zmsg_t *msg = fty_proto_encode_asset(aux, asset_name, FTY_PROTO_ASSET_OP_UPDATE, ext);
-        assert(msg);
-        mlm_client_send(asset_producer, "Asset message3", &msg);
-        zclock_sleep(1000);
-        zhash_destroy(&aux);
-        zhash_destroy(&ext);
+        zhash_t *aux = zhash_new ();
+        zhash_insert (aux, "priority", (void *) "1");
+        zhash_t *ext = zhash_new ();
+        zhash_insert (ext, "contact_name", (void *) "eaton Support team");
+        zhash_insert (ext, "name", (void *) asset_name);
+        zmsg_t *msg = fty_proto_encode_asset (aux, asset_name, FTY_PROTO_ASSET_OP_UPDATE, ext);
+        assert (msg);
+        mlm_client_send (asset_producer, "Asset message3", &msg);
+        zclock_sleep (1000);
+        zhash_destroy (&aux);
+        zhash_destroy (&ext);
 
         //      2. send alert message
-        zlist_t *actions = zlist_new();
-        zlist_autofree(actions);
-        zlist_append(actions, (void *) "EMAIL");
+        zlist_t *actions = zlist_new ();
+        zlist_autofree (actions);
+        zlist_append (actions, (void *) "EMAIL");
         msg = fty_proto_encode_alert
                 (NULL,
-                ::time(NULL),
-                600,
-                "NY_RULE2",
-                asset_name,
-                "ACTIVE",
-                "CRITICAL",
-                "ASDFKLHJH",
-                actions);
-        assert(msg);
-        std::string atopic2 = "NY_RULE2/CRITICAL@" + std::string(asset_name);
-        mlm_client_send(alert_producer, atopic2.c_str(), &msg);
-        zlist_destroy(&actions);
+                 ::time (NULL),
+                 600,
+                 "NY_RULE2",
+                 asset_name,
+                 "ACTIVE",
+                 "CRITICAL",
+                 "ASDFKLHJH",
+                 actions);
+        assert (msg);
+        std::string atopic2 = "NY_RULE2/CRITICAL@" + std::string (asset_name);
+        mlm_client_send (alert_producer, atopic2.c_str(), &msg);
+        zlist_destroy (&actions);
 
         //      3. check that we generate SENDMAIL_ALERT message with empty contact
-        msg = mlm_client_recv(email_client);
-        assert(msg);
-        assert(streq(mlm_client_subject(email_client), "SENDMAIL_ALERT"));
-        char *zuuid_str = zmsg_popstr(msg);
-        char *str = zmsg_popstr(msg);
-        assert(streq(str, "1"));
-        zstr_free(&str);
-        str = zmsg_popstr(msg);
-        assert(streq(str, asset_name));
-        zstr_free(&str);
-        str = zmsg_popstr(msg);
-        assert(streq(str, ""));
-        zstr_free(&str);
-        zmsg_destroy(&msg);
+        msg = mlm_client_recv (email_client);
+        assert (msg);
+        assert (streq (mlm_client_subject (email_client), "SENDMAIL_ALERT"));
+        char *zuuid_str = zmsg_popstr (msg);
+        char *str = zmsg_popstr (msg);
+        assert (streq (str, "1"));
+        zstr_free (&str);
+        str = zmsg_popstr (msg);
+        assert (streq (str, asset_name));
+        zstr_free (&str);
+        str = zmsg_popstr (msg);
+        assert (streq (str, ""));
+        zstr_free (&str);
+        zmsg_destroy (&msg);
 
         //       4. send the reply to unblock the actor
-        zmsg_t *reply = zmsg_new();
-        zmsg_addstr(reply, zuuid_str);
-        zmsg_addstr(reply, "OK");
-        zclock_sleep(1000);
-        mlm_client_sendto(email_client, FTY_ALERT_ACTIONS_TEST, "SENDMAIL_ALERT", NULL, 1000, &reply);
+        zmsg_t *reply = zmsg_new ();
+        zmsg_addstr (reply, zuuid_str);
+        zmsg_addstr (reply, "OK");
+        zclock_sleep (1000);
+        mlm_client_sendto (email_client, FTY_ALERT_ACTIONS_TEST, "SENDMAIL_ALERT", NULL, 1000, &reply);
 
-        zstr_free(&zuuid_str);
+        zstr_free (&zuuid_str);
     }
-    zclock_sleep(1000);
+    zclock_sleep (1000);
     //test 11: two alerts in quick succession, only one e-mail
     {
         zsys_debug("fty_alert_actions: test 11");
         const char *asset_name = "ASSET3";
-        zhash_t *aux = zhash_new();
-        zhash_insert(aux, "priority", (void *) "1");
-        zhash_t *ext = zhash_new();
-        zhash_insert(ext, "contact_email", (void *) "eaton Support team");
-        zhash_insert(ext, "name", (void *) asset_name);
-        zmsg_t *msg = fty_proto_encode_asset(aux, asset_name, FTY_PROTO_ASSET_OP_UPDATE, ext);
-        assert(msg);
-        mlm_client_send(asset_producer, "Asset message3", &msg);
-        zclock_sleep(1000);
-        zhash_destroy(&aux);
-        zhash_destroy(&ext);
+        zhash_t *aux = zhash_new ();
+        zhash_insert (aux, "priority", (void *) "1");
+        zhash_t *ext = zhash_new ();
+        zhash_insert (ext, "contact_email", (void *) "eaton Support team");
+        zhash_insert (ext, "name", (void *) asset_name);
+        zmsg_t *msg = fty_proto_encode_asset (aux, asset_name, FTY_PROTO_ASSET_OP_UPDATE, ext);
+        assert (msg);
+        mlm_client_send (asset_producer, "Asset message3", &msg);
+        zclock_sleep (1000);
+        zhash_destroy (&aux);
+        zhash_destroy (&ext);
 
         //      1. send an alert on the already known asset
-        std::string atopic = "NY_RULE3/CRITICAL@" + std::string(asset_name);
-        zlist_t *actions = zlist_new();
-        zlist_autofree(actions);
-        zlist_append(actions, (void *) "EMAIL");
+        std::string atopic = "NY_RULE3/CRITICAL@" + std::string (asset_name);
+        zlist_t *actions = zlist_new ();
+        zlist_autofree (actions);
+        zlist_append (actions, (void *) "EMAIL");
         msg = fty_proto_encode_alert
                 (NULL,
-                ::time(NULL),
-                600,
-                "NY_RULE3",
-                asset_name,
-                "ACTIVE",
-                "CRITICAL",
-                "ASDFKLHJH",
-                actions);
-        assert(msg);
-        mlm_client_send(alert_producer, atopic.c_str(), &msg);
-        zlist_destroy(&actions);
+                 ::time (NULL),
+                 600,
+                 "NY_RULE3",
+                 asset_name,
+                 "ACTIVE",
+                 "CRITICAL",
+                 "ASDFKLHJH",
+                 actions);
+        assert (msg);
+        mlm_client_send (alert_producer, atopic.c_str(), &msg);
+        zlist_destroy (&actions);
 
         //      2. read the SENDMAIL_ALERT message
-        msg = mlm_client_recv(email_client);
-        assert(msg);
-        assert(streq(mlm_client_subject(email_client), "SENDMAIL_ALERT"));
-        char *zuuid_str = zmsg_popstr(msg);
-        zmsg_destroy(&msg);
+        msg = mlm_client_recv (email_client);
+        assert (msg);
+        assert (streq (mlm_client_subject (email_client), "SENDMAIL_ALERT"));
+        char *zuuid_str = zmsg_popstr (msg);
+        zmsg_destroy (&msg);
 
         //       3. send the reply to unblock the actor
-        zmsg_t *reply = zmsg_new();
-        zmsg_addstr(reply, zuuid_str);
-        zmsg_addstr(reply, "OK");
-        assert(reply);
-        mlm_client_sendto(email_client, FTY_ALERT_ACTIONS_TEST, "SENDMAIL_ALERT", NULL, 1000, &reply);
+        zmsg_t *reply = zmsg_new ();
+        zmsg_addstr (reply, zuuid_str);
+        zmsg_addstr (reply, "OK");
+        assert (reply);
+        mlm_client_sendto (email_client, FTY_ALERT_ACTIONS_TEST, "SENDMAIL_ALERT", NULL, 1000, &reply);
 
-        zstr_free(&zuuid_str);
+        zstr_free (&zuuid_str);
 
         //      4. send an alert on the already known asset
-        actions = zlist_new();
-        zlist_autofree(actions);
-        zlist_append(actions, (void *) "EMAIL");
+        actions = zlist_new ();
+        zlist_autofree (actions);
+        zlist_append (actions, (void *) "EMAIL");
         msg = fty_proto_encode_alert
                 (NULL,
-                ::time(NULL),
-                600,
-                "NY_RULE3",
-                asset_name,
-                "ACTIVE",
-                "CRITICAL",
-                "ASDFKLHJH",
-                actions);
-        assert(msg);
-        mlm_client_send(alert_producer, atopic.c_str(), &msg);
-        zlist_destroy(&actions);
+                 ::time (NULL),
+                 600,
+                 "NY_RULE3",
+                 asset_name,
+                 "ACTIVE",
+                 "CRITICAL",
+                 "ASDFKLHJH",
+                 actions);
+        assert (msg);
+        mlm_client_send (alert_producer, atopic.c_str(), &msg);
+        zlist_destroy (&actions);
 
         //      5. check that we don't send SENDMAIL_ALERT message (notification interval)
-        zpoller_t *poller = zpoller_new(mlm_client_msgpipe(email_client), NULL);
-        void *which = zpoller_wait(poller, 1000);
-        assert(which == NULL);
-        if (verbose) {
-            zsys_debug("No email was sent: SUCCESS");
+        zpoller_t *poller = zpoller_new (mlm_client_msgpipe (email_client), NULL);
+        void *which = zpoller_wait (poller, 1000);
+        assert ( which == NULL );
+        if ( verbose ) {
+            zsys_debug ("No email was sent: SUCCESS");
         }
-        zpoller_destroy(&poller);
+        zpoller_destroy (&poller);
     }
     //test 12, alert without action "EMAIL"
     {
         zsys_debug("fty_alert_actions: test 12");
         const char *asset_name = "ASSET4";
-        zhash_t *aux = zhash_new();
-        zhash_insert(aux, "priority", (void *) "1");
-        zhash_t *ext = zhash_new();
-        zhash_insert(ext, "contact_email", (void *) "eaton Support team");
-        zhash_insert(ext, "name", (void *) asset_name);
-        zmsg_t *msg = fty_proto_encode_asset(aux, asset_name, FTY_PROTO_ASSET_OP_UPDATE, ext);
-        assert(msg);
-        mlm_client_send(asset_producer, "Asset message4", &msg);
-        zclock_sleep(1000);
-        zhash_destroy(&aux);
-        zhash_destroy(&ext);
+        zhash_t *aux = zhash_new ();
+        zhash_insert (aux, "priority", (void *) "1");
+        zhash_t *ext = zhash_new ();
+        zhash_insert (ext, "contact_email", (void *) "eaton Support team");
+        zhash_insert (ext, "name", (void *) asset_name);
+        zmsg_t *msg = fty_proto_encode_asset (aux, asset_name, FTY_PROTO_ASSET_OP_UPDATE, ext);
+        assert (msg);
+        mlm_client_send (asset_producer, "Asset message4", &msg);
+        zclock_sleep (1000);
+        zhash_destroy (&aux);
+        zhash_destroy (&ext);
 
         //      1. send alert message
-        std::string atopic = "NY_RULE4/CRITICAL@" + std::string(asset_name);
-        zlist_t *actions = zlist_new();
-        zlist_autofree(actions);
+        std::string atopic = "NY_RULE4/CRITICAL@" + std::string (asset_name);
+        zlist_t *actions = zlist_new ();
+        zlist_autofree (actions);
         msg = fty_proto_encode_alert
-                (NULL,
-                ::time(NULL),
-                600,
-                "NY_RULE4",
-                asset_name,
-                "ACTIVE",
-                "CRITICAL",
-                "ASDFKLHJH",
-                actions);
-        assert(msg);
-        mlm_client_send(alert_producer, atopic.c_str(), &msg);
-        zlist_destroy(&actions);
+            (NULL,
+             ::time (NULL),
+             600,
+             "NY_RULE4",
+             asset_name,
+             "ACTIVE",
+             "CRITICAL",
+             "ASDFKLHJH",
+             actions);
+        assert (msg);
+        mlm_client_send (alert_producer, atopic.c_str(), &msg);
+        zlist_destroy (&actions);
 
         //      2. we don't send SENDMAIL_ALERT message
-        zpoller_t *poller = zpoller_new(mlm_client_msgpipe(email_client), NULL);
-        void *which = zpoller_wait(poller, 1000);
-        assert(which == NULL);
-        if (verbose) {
-            zsys_debug("No email was sent: SUCCESS");
+        zpoller_t *poller = zpoller_new (mlm_client_msgpipe (email_client), NULL);
+        void *which = zpoller_wait (poller, 1000);
+        assert ( which == NULL );
+        if ( verbose ) {
+            zsys_debug ("No email was sent: SUCCESS");
         }
-        zpoller_destroy(&poller);
+        zpoller_destroy (&poller);
     }
     // test13  ===============================================
     //
@@ -1645,109 +1690,109 @@ fty_alert_actions_test(bool verbose) {
         zsys_debug("fty_alert_actions: test 13");
         const char *asset_name6 = "asset_6";
         const char *rule_name6 = "rule_name_6";
-        std::string alert_topic6 = std::string(rule_name6) + "/CRITICAL@" + std::string(asset_name6);
+        std::string alert_topic6 = std::string(rule_name6) + "/CRITICAL@" + std::string (asset_name6);
 
         //      1. send asset info without email
-        zhash_t *aux = zhash_new();
-        assert(aux);
-        zhash_insert(aux, "priority", (void *) "1");
-        zhash_t *ext = zhash_new();
-        assert(ext);
-        zhash_insert(ext, "name", (void *) asset_name6);
-        zmsg_t *msg = fty_proto_encode_asset(aux, asset_name6, FTY_PROTO_ASSET_OP_UPDATE, ext);
-        assert(msg);
-        int rv = mlm_client_send(asset_producer, "Asset message6", &msg);
-        assert(rv != -1);
+        zhash_t *aux = zhash_new ();
+        assert (aux);
+        zhash_insert (aux, "priority", (void *) "1");
+        zhash_t *ext = zhash_new ();
+        assert (ext);
+        zhash_insert (ext, "name", (void *) asset_name6);
+        zmsg_t *msg = fty_proto_encode_asset (aux, asset_name6, FTY_PROTO_ASSET_OP_UPDATE, ext);
+        assert (msg);
+        int rv = mlm_client_send (asset_producer, "Asset message6", &msg);
+        assert ( rv != -1 );
         // Ensure, that malamute will deliver ASSET message before ALERT message
-        zclock_sleep(1000);
+        zclock_sleep (1000);
 
         //      2. send alert message
-        zlist_t *actions = zlist_new();
-        zlist_autofree(actions);
-        zlist_append(actions, (void *) "EMAIL");
+        zlist_t *actions = zlist_new ();
+        zlist_autofree (actions);
+        zlist_append (actions, (void *) "EMAIL");
         msg = fty_proto_encode_alert
                 (NULL,
-                ::time(NULL),
-                600,
-                rule_name6,
-                asset_name6,
-                "ACTIVE",
-                "CRITICAL",
-                "ASDFKLHJH",
-                actions);
-        assert(msg);
-        rv = mlm_client_send(alert_producer, alert_topic6.c_str(), &msg);
-        assert(rv != -1);
-        zlist_destroy(&actions);
+                 ::time (NULL),
+                 600,
+                 rule_name6,
+                 asset_name6,
+                 "ACTIVE",
+                 "CRITICAL",
+                 "ASDFKLHJH",
+                 actions);
+        assert (msg);
+        rv = mlm_client_send (alert_producer, alert_topic6.c_str(), &msg);
+        assert ( rv != -1 );
+        zlist_destroy (&actions);
 
         //      3. check that we generate SENDMAIL_ALERT message with empty contact
-        zmsg_t *email = mlm_client_recv(email_client);
-        assert(email);
-        assert(streq(mlm_client_subject(email_client), "SENDMAIL_ALERT"));
-        char *zuuid_str = zmsg_popstr(email);
-        char *str = zmsg_popstr(email);
-        assert(streq(str, "1"));
-        zstr_free(&str);
-        str = zmsg_popstr(email);
-        assert(streq(str, asset_name6));
-        zstr_free(&str);
-        str = zmsg_popstr(email);
-        assert(streq(str, ""));
-        zstr_free(&str);
-        zmsg_destroy(&email);
+        zmsg_t *email = mlm_client_recv (email_client);
+        assert (email);
+        assert (streq (mlm_client_subject (email_client), "SENDMAIL_ALERT"));
+        char *zuuid_str = zmsg_popstr (email);
+        char *str = zmsg_popstr (email);
+        assert (streq (str, "1"));
+        zstr_free (&str);
+        str = zmsg_popstr (email);
+        assert (streq (str, asset_name6));
+        zstr_free (&str);
+        str = zmsg_popstr (email);
+        assert (streq (str, ""));
+        zstr_free (&str);
+        zmsg_destroy (&email);
 
         //       4. send the reply to unblock the actor
-        zmsg_t *reply = zmsg_new();
-        zmsg_addstr(reply, zuuid_str);
-        zmsg_addstr(reply, "OK");
-        mlm_client_sendto(email_client, FTY_ALERT_ACTIONS_TEST, "SENDMAIL_ALERT", NULL, 1000, &reply);
+        zmsg_t *reply = zmsg_new ();
+        zmsg_addstr (reply, zuuid_str);
+        zmsg_addstr (reply, "OK");
+        mlm_client_sendto (email_client, FTY_ALERT_ACTIONS_TEST, "SENDMAIL_ALERT", NULL, 1000, &reply);
 
-        zstr_free(&zuuid_str);
+        zstr_free (&zuuid_str);
 
         //      5. send asset info one more time, but with email
-        zhash_insert(ext, "contact_email", (void *) "scenario6.email@eaton.com");
-        msg = fty_proto_encode_asset(aux, asset_name6, "update", ext);
-        assert(msg);
-        rv = mlm_client_send(asset_producer, "Asset message6", &msg);
-        assert(rv != -1);
+        zhash_insert (ext, "contact_email", (void *) "scenario6.email@eaton.com");
+        msg = fty_proto_encode_asset (aux, asset_name6, "update", ext);
+        assert (msg);
+        rv = mlm_client_send (asset_producer, "Asset message6", &msg);
+        assert ( rv != -1 );
         // Ensure, that malamute will deliver ASSET message before ALERT message
-        zhash_destroy(&aux);
-        zhash_destroy(&ext);
-        zclock_sleep(1000);
+        zhash_destroy (&aux);
+        zhash_destroy (&ext);
+        zclock_sleep (1000);
 
         //      5. send alert message again
-        actions = zlist_new();
-        zlist_autofree(actions);
-        zlist_append(actions, (void *) "EMAIL");
+        actions = zlist_new ();
+        zlist_autofree (actions);
+        zlist_append (actions, (void *) "EMAIL");
         msg = fty_proto_encode_alert
                 (NULL,
-                ::time(NULL),
-                600,
-                rule_name6,
-                asset_name6,
-                "ACTIVE",
-                "CRITICAL",
-                "ASDFKLHJH",
-                actions);
-        assert(msg);
-        rv = mlm_client_send(alert_producer, alert_topic6.c_str(), &msg);
-        assert(rv != -1);
-        zlist_destroy(&actions);
+                 ::time (NULL),
+                 600,
+                 rule_name6,
+                 asset_name6,
+                 "ACTIVE",
+                 "CRITICAL",
+                 "ASDFKLHJH",
+                 actions);
+        assert (msg);
+        rv = mlm_client_send (alert_producer, alert_topic6.c_str(), &msg);
+        assert ( rv != -1 );
+        zlist_destroy (&actions);
 
         //      6. Email SHOULD be generated
-        msg = mlm_client_recv(email_client);
-        assert(msg);
-        assert(streq(mlm_client_subject(email_client), "SENDMAIL_ALERT"));
-        zuuid_str = zmsg_popstr(msg);
-        zmsg_destroy(&msg);
+        msg = mlm_client_recv (email_client);
+        assert (msg);
+        assert (streq (mlm_client_subject (email_client), "SENDMAIL_ALERT"));
+        zuuid_str = zmsg_popstr (msg);
+        zmsg_destroy (&msg);
 
         //       7. send the reply to unblock the actor
-        reply = zmsg_new();
-        zmsg_addstr(reply, zuuid_str);
-        zmsg_addstr(reply, "OK");
-        mlm_client_sendto(email_client, FTY_ALERT_ACTIONS_TEST, "SENDMAIL_ALERT", NULL, 1000, &reply);
+        reply = zmsg_new ();
+        zmsg_addstr (reply, zuuid_str);
+        zmsg_addstr (reply, "OK");
+        mlm_client_sendto (email_client, FTY_ALERT_ACTIONS_TEST, "SENDMAIL_ALERT", NULL, 1000, &reply);
 
-        zstr_free(&zuuid_str);
+        zstr_free (&zuuid_str);
     }
     //test 14, on ACK-SILENCE we send only one e-mail and then stop
     {
@@ -1755,119 +1800,119 @@ fty_alert_actions_test(bool verbose) {
         //      1. send an alert on the already known asset
         const char *asset_name = "ASSET7";
         //      1. send asset info without email
-        zhash_t *aux = zhash_new();
-        assert(aux);
-        zhash_insert(aux, "priority", (void *) "1");
-        zhash_t *ext = zhash_new();
-        assert(ext);
-        zhash_insert(ext, "name", (void *) asset_name);
-        zmsg_t *msg = fty_proto_encode_asset(aux, asset_name, FTY_PROTO_ASSET_OP_UPDATE, ext);
-        assert(msg);
-        int rv = mlm_client_send(asset_producer, "Asset message6", &msg);
-        assert(rv != -1);
+        zhash_t *aux = zhash_new ();
+        assert (aux);
+        zhash_insert (aux, "priority", (void *) "1");
+        zhash_t *ext = zhash_new ();
+        assert (ext);
+        zhash_insert (ext, "name", (void *) asset_name);
+        zmsg_t *msg = fty_proto_encode_asset (aux, asset_name, FTY_PROTO_ASSET_OP_UPDATE, ext);
+        assert (msg);
+        int rv = mlm_client_send (asset_producer, "Asset message6", &msg);
+        assert ( rv != -1 );
         // Ensure, that malamute will deliver ASSET message before ALERT message
-        zclock_sleep(1000);
-        zhash_destroy(&aux);
-        zhash_destroy(&ext);
+        zclock_sleep (1000);
+        zhash_destroy (&aux);
+        zhash_destroy (&ext);
 
-        std::string atopic = "Scenario7/CRITICAL@" + std::string(asset_name);
-        zlist_t *actions = zlist_new();
-        zlist_autofree(actions);
-        zlist_append(actions, (void *) "EMAIL");
+        std::string atopic = "Scenario7/CRITICAL@" + std::string (asset_name);
+        zlist_t *actions = zlist_new ();
+        zlist_autofree (actions);
+        zlist_append (actions, (void *) "EMAIL");
         msg = fty_proto_encode_alert
                 (NULL,
-                ::time(NULL),
-                600,
-                "Scenario7",
-                asset_name,
-                "ACTIVE",
-                "CRITICAL",
-                "ASDFKLHJH",
-                actions);
-        assert(msg);
-        mlm_client_send(alert_producer, atopic.c_str(), &msg);
-        zlist_destroy(&actions);
+                 ::time (NULL),
+                 600,
+                 "Scenario7",
+                 asset_name,
+                 "ACTIVE",
+                 "CRITICAL",
+                 "ASDFKLHJH",
+                 actions);
+        assert (msg);
+        mlm_client_send (alert_producer, atopic.c_str(), &msg);
+        zlist_destroy (&actions);
 
         //      2. read the email generated for alert
-        msg = mlm_client_recv(email_client);
-        assert(msg);
-        assert(streq(mlm_client_subject(email_client), "SENDMAIL_ALERT"));
-        char *zuuid_str = zmsg_popstr(msg);
-        zmsg_destroy(&msg);
+        msg = mlm_client_recv (email_client);
+        assert (msg);
+        assert (streq (mlm_client_subject (email_client), "SENDMAIL_ALERT"));
+        char *zuuid_str = zmsg_popstr (msg);
+        zmsg_destroy (&msg);
 
         //       3. send the reply to unblock the actor
-        zmsg_t *reply = zmsg_new();
-        zmsg_addstr(reply, zuuid_str);
-        zmsg_addstr(reply, "OK");
-        mlm_client_sendto(email_client, FTY_ALERT_ACTIONS_TEST, "SENDMAIL_ALERT", NULL, 1000, &reply);
+        zmsg_t *reply = zmsg_new ();
+        zmsg_addstr (reply, zuuid_str);
+        zmsg_addstr (reply, "OK");
+        mlm_client_sendto (email_client, FTY_ALERT_ACTIONS_TEST, "SENDMAIL_ALERT", NULL, 1000, &reply);
 
-        zstr_free(&zuuid_str);
+        zstr_free (&zuuid_str);
 
         //      4. send an alert on the already known asset
-        actions = zlist_new();
-        zlist_autofree(actions);
-        zlist_append(actions, (void *) "EMAIL");
+        actions = zlist_new ();
+        zlist_autofree (actions);
+        zlist_append (actions, (void *) "EMAIL");
         msg = fty_proto_encode_alert
                 (NULL,
-                ::time(NULL),
-                600,
-                "Scenario7",
-                asset_name,
-                "ACK-SILENCE",
-                "CRITICAL",
-                "ASDFKLHJH",
-                actions);
-        assert(msg);
-        mlm_client_send(alert_producer, atopic.c_str(), &msg);
-        zlist_destroy(&actions);
+                 ::time (NULL),
+                 600,
+                 "Scenario7",
+                 asset_name,
+                 "ACK-SILENCE",
+                 "CRITICAL",
+                 "ASDFKLHJH",
+                 actions);
+        assert (msg);
+        mlm_client_send (alert_producer, atopic.c_str(), &msg);
+        zlist_destroy (&actions);
 
         //      5. read the email generated for alert
-        msg = mlm_client_recv(email_client);
-        assert(msg);
-        assert(streq(mlm_client_subject(email_client), "SENDMAIL_ALERT"));
-        zuuid_str = zmsg_popstr(msg);
-        zmsg_destroy(&msg);
+        msg = mlm_client_recv (email_client);
+        assert (msg);
+        assert (streq (mlm_client_subject (email_client), "SENDMAIL_ALERT"));
+        zuuid_str = zmsg_popstr (msg);
+        zmsg_destroy (&msg);
 
         //       6. send the reply to unblock the actor
-        reply = zmsg_new();
-        zmsg_addstr(reply, zuuid_str);
-        zmsg_addstr(reply, "OK");
-        mlm_client_sendto(email_client, FTY_ALERT_ACTIONS_TEST, "SENDMAIL_ALERT", NULL, 1000, &reply);
+        reply = zmsg_new ();
+        zmsg_addstr (reply, zuuid_str);
+        zmsg_addstr (reply, "OK");
+        mlm_client_sendto (email_client, FTY_ALERT_ACTIONS_TEST, "SENDMAIL_ALERT", NULL, 1000, &reply);
 
-        zstr_free(&zuuid_str);
+        zstr_free (&zuuid_str);
 
         // wait for 5 minutes
-        zstr_sendx(alert_actions, "TESTTIMEOUT", "1000", NULL);
-        zstr_sendx(alert_actions, "TESTCHECKINTERVAL", "20000", NULL);
-        zsys_debug("sleeping for 20 seconds...");
-        zclock_sleep(20 * 1000);
+        zstr_sendx (alert_actions, "TESTTIMEOUT", "1000", NULL);
+        zstr_sendx (alert_actions, "TESTCHECKINTERVAL", "20000", NULL);
+        zsys_debug ("sleeping for 20 seconds...");
+        zclock_sleep (20 * 1000);
         //      7. send an alert again
-        actions = zlist_new();
-        zlist_autofree(actions);
-        zlist_append(actions, (void *) "EMAIL");
+        actions = zlist_new ();
+        zlist_autofree (actions);
+        zlist_append (actions, (void *) "EMAIL");
         msg = fty_proto_encode_alert
-                (NULL,
-                ::time(NULL),
-                600,
-                "Scenario7",
-                asset_name,
-                "ACK-SILENCE",
-                "CRITICAL",
-                "ASDFKLHJH",
-                actions);
-        assert(msg);
-        mlm_client_send(alert_producer, atopic.c_str(), &msg);
-        zlist_destroy(&actions);
+            (NULL,
+             ::time (NULL),
+             600,
+             "Scenario7",
+             asset_name,
+             "ACK-SILENCE",
+             "CRITICAL",
+             "ASDFKLHJH",
+             actions);
+        assert (msg);
+        mlm_client_send (alert_producer, atopic.c_str(), &msg);
+        zlist_destroy (&actions);
 
         //      8. email should not be sent (it is in the state, where alerts are not being sent)
-        zpoller_t *poller = zpoller_new(mlm_client_msgpipe(email_client), NULL);
-        void *which = zpoller_wait(poller, 1000);
-        assert(which == NULL);
-        if (verbose) {
-            zsys_debug("No email was sent: SUCCESS");
+        zpoller_t *poller = zpoller_new (mlm_client_msgpipe (email_client), NULL);
+        void *which = zpoller_wait (poller, 1000);
+        assert ( which == NULL );
+        if ( verbose ) {
+            zsys_debug ("No email was sent: SUCCESS");
         }
-        zpoller_destroy(&poller);
-        zclock_sleep(1500);
+        zpoller_destroy (&poller);
+        zclock_sleep (1500);
     }
     //test 15 ===============================================
     //
@@ -1879,195 +1924,196 @@ fty_alert_actions_test(bool verbose) {
         zsys_debug("fty_alert_actions: test 15");
         const char *asset_name8 = "ROZ.UPS36";
         const char *rule_name8 = "rule_name_8";
-        std::string alert_topic8 = std::string(rule_name8) + "/CRITICAL@" + std::string(asset_name8);
+        std::string alert_topic8 = std::string(rule_name8) + "/CRITICAL@" + std::string (asset_name8);
 
         //      1. send asset info without email
-        zhash_t *aux = zhash_new();
-        assert(aux);
-        zhash_insert(aux, "priority", (void *) "1");
-        zhash_t *ext = zhash_new();
-        assert(ext);
-        zhash_insert(ext, "name", (void *) asset_name8);
-        zmsg_t *msg = fty_proto_encode_asset(aux, asset_name8, FTY_PROTO_ASSET_OP_UPDATE, ext);
-        assert(msg);
-        int rv = mlm_client_send(asset_producer, "Asset message8", &msg);
-        assert(rv != -1);
-        zclock_sleep(1000);
+        zhash_t *aux = zhash_new ();
+        assert (aux);
+        zhash_insert (aux, "priority", (void *) "1");
+        zhash_t *ext = zhash_new ();
+        assert (ext);
+        zhash_insert (ext, "name", (void *) asset_name8);
+        zmsg_t *msg = fty_proto_encode_asset (aux, asset_name8, FTY_PROTO_ASSET_OP_UPDATE, ext);
+        assert (msg);
+        int rv = mlm_client_send (asset_producer, "Asset message8", &msg);
+        assert ( rv != -1 );
+        zclock_sleep (1000);
 
         //      2. send alert message
-        zlist_t *actions = zlist_new();
-        zlist_autofree(actions);
-        zlist_append(actions, (void *) "EMAIL");
-        zlist_append(actions, (void *) "SMS");
+        zlist_t *actions = zlist_new ();
+        zlist_autofree (actions);
+        zlist_append (actions, (void *) "EMAIL");
+        zlist_append (actions, (void *) "SMS");
         msg = fty_proto_encode_alert
-                (NULL,
-                ::time(NULL),
-                600,
-                rule_name8,
-                asset_name8,
-                "ACTIVE",
-                "WARNING",
-                "Default load in ups ROZ.UPS36 is high",
-                actions);
-        assert(msg);
-        rv = mlm_client_send(alert_producer, alert_topic8.c_str(), &msg);
-        assert(rv != -1);
-        zlist_destroy(&actions);
+            (NULL,
+             ::time (NULL),
+             600,
+             rule_name8,
+             asset_name8,
+             "ACTIVE",
+             "WARNING",
+             "Default load in ups ROZ.UPS36 is high",
+             actions);
+        assert (msg);
+        rv = mlm_client_send (alert_producer, alert_topic8.c_str(), &msg);
+        assert ( rv != -1 );
+        zlist_destroy (&actions);
 
         //      3. check that we generate SENDMAIL_ALERT message with empty contact
-        zmsg_t *email = mlm_client_recv(email_client);
-        assert(email);
-        assert(streq(mlm_client_subject(email_client), "SENDMAIL_ALERT"));
-        char *zuuid_str = zmsg_popstr(email);
-        char *str = zmsg_popstr(email);
-        assert(streq(str, "1"));
-        zstr_free(&str);
-        str = zmsg_popstr(email);
-        assert(streq(str, asset_name8));
-        zstr_free(&str);
-        str = zmsg_popstr(email);
-        assert(streq(str, ""));
-        zstr_free(&str);
-        zmsg_destroy(&email);
+        zmsg_t *email = mlm_client_recv (email_client);
+        assert (email);
+        assert (streq (mlm_client_subject (email_client), "SENDMAIL_ALERT"));
+        char *zuuid_str = zmsg_popstr (email);
+        char *str = zmsg_popstr (email);
+        assert (streq (str, "1"));
+        zstr_free (&str);
+        str = zmsg_popstr (email);
+        assert (streq (str, asset_name8));
+        zstr_free (&str);
+        str = zmsg_popstr (email);
+        assert (streq (str, ""));
+        zstr_free (&str);
+        zmsg_destroy (&email);
 
         //       4. send the reply to unblock the actor
-        zmsg_t *reply = zmsg_new();
-        zmsg_addstr(reply, zuuid_str);
-        zmsg_addstr(reply, "OK");
-        zclock_sleep(1000);
-        mlm_client_sendto(email_client, FTY_ALERT_ACTIONS_TEST, "SENDMAIL_ALERT", NULL, 1000, &reply);
+        zmsg_t *reply = zmsg_new ();
+        zmsg_addstr (reply, zuuid_str);
+        zmsg_addstr (reply, "OK");
+        zclock_sleep (1000);
+        mlm_client_sendto (email_client, FTY_ALERT_ACTIONS_TEST, "SENDMAIL_ALERT", NULL, 1000, &reply);
 
-        zstr_free(&zuuid_str);
-        zclock_sleep(1000);
+        zstr_free (&zuuid_str);
+        zclock_sleep (1000);
 
         //      3. check that we generate SENDSMS_ALERT message with empty contact
-        email = mlm_client_recv(email_client);
-        assert(email);
-        zsys_debug(mlm_client_subject(email_client));
-        assert(streq(mlm_client_subject(email_client), "SENDSMS_ALERT"));
-        zuuid_str = zmsg_popstr(email);
-        str = zmsg_popstr(email);
-        assert(streq(str, "1"));
-        zstr_free(&str);
-        str = zmsg_popstr(email);
-        assert(streq(str, asset_name8));
-        zstr_free(&str);
-        str = zmsg_popstr(email);
-        assert(streq(str, ""));
-        zstr_free(&str);
-        zmsg_destroy(&email);
+        email = mlm_client_recv (email_client);
+        assert (email);
+        zsys_debug(mlm_client_subject (email_client));
+        assert (streq (mlm_client_subject (email_client), "SENDSMS_ALERT"));
+        zuuid_str = zmsg_popstr (email);
+        str = zmsg_popstr (email);
+        assert (streq (str, "1"));
+        zstr_free (&str);
+        str = zmsg_popstr (email);
+        assert (streq (str, asset_name8));
+        zstr_free (&str);
+        str = zmsg_popstr (email);
+        assert (streq (str, ""));
+        zstr_free (&str);
+        zmsg_destroy (&email);
 
         //       4. send the reply to unblock the actor
-        reply = zmsg_new();
-        zmsg_addstr(reply, zuuid_str);
-        zmsg_addstr(reply, "OK");
-        mlm_client_sendto(email_client, FTY_ALERT_ACTIONS_TEST, "SENDMAIL_ALERT", NULL, 1000, &reply);
+        reply = zmsg_new ();
+        zmsg_addstr (reply, zuuid_str);
+        zmsg_addstr (reply, "OK");
+        mlm_client_sendto (email_client, FTY_ALERT_ACTIONS_TEST, "SENDMAIL_ALERT", NULL, 1000, &reply);
 
-        zstr_free(&zuuid_str);
+        zstr_free (&zuuid_str);
 
         //      5. send asset info one more time, but with email
-        zhash_insert(ext, "contact_email", (void *) "scenario8.email@eaton.com");
-        msg = fty_proto_encode_asset(aux, asset_name8, "update", ext);
-        assert(msg);
-        rv = mlm_client_send(asset_producer, "Asset message8", &msg);
-        assert(rv != -1);
+        zhash_insert (ext, "contact_email", (void *) "scenario8.email@eaton.com");
+        msg = fty_proto_encode_asset (aux, asset_name8, "update", ext);
+        assert (msg);
+        rv = mlm_client_send (asset_producer, "Asset message8", &msg);
+        assert ( rv != -1 );
 
-        zhash_destroy(&aux);
-        zhash_destroy(&ext);
-        zclock_sleep(1000);
+        zhash_destroy (&aux);
+        zhash_destroy (&ext);
+        zclock_sleep (1000);
+
         //      6. send alert message again second
-        actions = zlist_new();
-        zlist_autofree(actions);
-        zlist_append(actions, (void *) "EMAIL");
-        zlist_append(actions, (void *) "SMS");
+        actions = zlist_new ();
+        zlist_autofree (actions);
+        zlist_append (actions, (void *) "EMAIL");
+        zlist_append (actions, (void *) "SMS");
         msg = fty_proto_encode_alert
-                (NULL,
-                ::time(NULL),
-                600,
-                rule_name8,
-                asset_name8,
-                "ACTIVE",
-                "WARNING",
-                "Default load in ups ROZ.UPS36 is high",
-                actions);
-        assert(msg);
-        rv = mlm_client_send(alert_producer, alert_topic8.c_str(), &msg);
-        assert(rv != -1);
-        zlist_destroy(&actions);
+            (NULL,
+             ::time (NULL),
+             600,
+             rule_name8,
+             asset_name8,
+             "ACTIVE",
+             "WARNING",
+             "Default load in ups ROZ.UPS36 is high",
+             actions);
+        assert (msg);
+        rv = mlm_client_send (alert_producer, alert_topic8.c_str(), &msg);
+        assert ( rv != -1 );
+        zlist_destroy (&actions);
 
         //      6. Email SHOULD be generated
-        msg = mlm_client_recv(email_client);
-        assert(msg);
-        if (verbose)
-            zsys_debug("Email was sent: SUCCESS");
-        assert(streq(mlm_client_subject(email_client), "SENDMAIL_ALERT"));
-        zuuid_str = zmsg_popstr(msg);
-        zmsg_destroy(&msg);
-        zclock_sleep(1000);
+        msg = mlm_client_recv (email_client);
+        assert (msg);
+        if ( verbose )
+            zsys_debug ("Email was sent: SUCCESS");
+        assert (streq (mlm_client_subject (email_client), "SENDMAIL_ALERT"));
+        zuuid_str = zmsg_popstr (msg);
+        zmsg_destroy (&msg);
+        zclock_sleep (1000);
 
         //       7. send the reply to unblock the actor
-        reply = zmsg_new();
-        zmsg_addstr(reply, zuuid_str);
-        zmsg_addstr(reply, "OK");
-        mlm_client_sendto(email_client, FTY_ALERT_ACTIONS_TEST, "SENDMAIL_ALERT", NULL, 1000, &reply);
+        reply = zmsg_new ();
+        zmsg_addstr (reply, zuuid_str);
+        zmsg_addstr (reply, "OK");
+        mlm_client_sendto (email_client, FTY_ALERT_ACTIONS_TEST, "SENDMAIL_ALERT", NULL, 1000, &reply);
 
-        zstr_free(&zuuid_str);
-        zclock_sleep(1000);
+        zstr_free (&zuuid_str);
+        zclock_sleep (1000);
 
         //      6. SMS SHOULD be generated
-        msg = mlm_client_recv(email_client);
-        assert(msg);
-        if (verbose)
-            zsys_debug("SMS was sent: SUCCESS");
-        assert(streq(mlm_client_subject(email_client), "SENDSMS_ALERT"));
-        zuuid_str = zmsg_popstr(msg);
-        zmsg_destroy(&msg);
-        zclock_sleep(1000);
+        msg = mlm_client_recv (email_client);
+        assert (msg);
+        if ( verbose )
+            zsys_debug ("SMS was sent: SUCCESS");
+        assert (streq (mlm_client_subject (email_client), "SENDSMS_ALERT"));
+        zuuid_str = zmsg_popstr (msg);
+        zmsg_destroy (&msg);
+        zclock_sleep (1000);
 
         //       7. send the reply to unblock the actor
-        reply = zmsg_new();
-        zmsg_addstr(reply, zuuid_str);
-        zmsg_addstr(reply, "OK");
-        mlm_client_sendto(email_client, FTY_ALERT_ACTIONS_TEST, "SENDSMS_ALERT", NULL, 1000, &reply);
-        zclock_sleep(1000);
+        reply = zmsg_new ();
+        zmsg_addstr (reply, zuuid_str);
+        zmsg_addstr (reply, "OK");
+        mlm_client_sendto (email_client, FTY_ALERT_ACTIONS_TEST, "SENDSMS_ALERT", NULL, 1000, &reply);
+        zclock_sleep (1000);
 
-        zstr_free(&zuuid_str);
+        zstr_free (&zuuid_str);
 
         //      8. send alert message again third time
-        actions = zlist_new();
-        zlist_autofree(actions);
-        zlist_append(actions, (void *) "EMAIL");
-        zlist_append(actions, (void *) "SMS");
+        actions = zlist_new ();
+        zlist_autofree (actions);
+        zlist_append (actions, (void *) "EMAIL");
+        zlist_append (actions, (void *) "SMS");
         msg = fty_proto_encode_alert
-                (NULL,
-                ::time(NULL),
-                600,
-                rule_name8,
-                asset_name8,
-                "ACTIVE",
-                "WARNING",
-                "Default load in ups ROZ.UPS36 is high",
-                actions);
-        assert(msg);
-        rv = mlm_client_send(alert_producer, alert_topic8.c_str(), &msg);
-        assert(rv != -1);
-        zlist_destroy(&actions);
+            (NULL,
+             ::time(NULL),
+             600,
+             rule_name8,
+             asset_name8,
+             "ACTIVE",
+             "WARNING",
+             "Default load in ups ROZ.UPS36 is high",
+             actions);
+        assert (msg);
+        rv = mlm_client_send (alert_producer, alert_topic8.c_str(), &msg);
+        assert ( rv != -1 );
+        zlist_destroy (&actions);
 
         //      9. Email SHOULD NOT be generated
-        zclock_sleep(1000);
-        zpoller_t *poller = zpoller_new(mlm_client_msgpipe(email_client), NULL);
-        void *which = zpoller_wait(poller, 1000);
-        assert(which == NULL);
-        if (verbose)
-            zsys_debug("Email was NOT sent: SUCCESS");
-        zpoller_destroy(&poller);
+        zclock_sleep (1000);
+        zpoller_t *poller = zpoller_new (mlm_client_msgpipe (email_client), NULL);
+        void *which = zpoller_wait (poller, 1000);
+        assert ( which == NULL );
+        if ( verbose )
+            zsys_debug ("Email was NOT sent: SUCCESS");
+        zpoller_destroy (&poller);
     }
     //  @end
-    mlm_client_destroy(&email_client);
-    mlm_client_destroy(&alert_producer);
-    mlm_client_destroy(&asset_producer);
-    zactor_destroy(&alert_actions);
-    zactor_destroy(&server);
-    printf("OK\n");
+    mlm_client_destroy (&email_client);
+    mlm_client_destroy (&alert_producer);
+    mlm_client_destroy (&asset_producer);
+    zactor_destroy (&alert_actions);
+    zactor_destroy (&server);
+    printf ("OK\n");
 }
 

--- a/src/fty_alert_engine.cc
+++ b/src/fty_alert_engine.cc
@@ -14,7 +14,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
- */
+*/
 
 /*! \file fty_alert_engine.cc
  *  \author Alena Chernikava <AlenaChernikava@Eaton.com>
@@ -37,12 +37,14 @@ static const char *AUTOCONFIG_NAME = "fty-autoconfig";
 // malamute endpoint
 static const char *ENDPOINT = "ipc://@/malamute";
 
-int main(int argc, char** argv) {
+int main (int argc, char** argv)
+{
     bool set_verbose = false;
-    char* fty_log_level = getenv("BIOS_LOG_LEVEL");
-    if (argc == 2 && streq(argv[1], "-v")) {
+    char* fty_log_level = getenv ("BIOS_LOG_LEVEL");
+    if (argc == 2 && streq (argv[1], "-v")) {
         set_verbose = true;
-    } else if (fty_log_level && streq(fty_log_level, "LOG_DEBUG")) {
+    }
+    else if (fty_log_level && streq (fty_log_level, "LOG_DEBUG")) {
         set_verbose = true;
     }
 
@@ -67,23 +69,23 @@ int main(int argc, char** argv) {
 
 
     //autoconfig
-    zactor_t *ag_configurator = zactor_new(autoconfig, (void*) AUTOCONFIG_NAME);
+    zactor_t *ag_configurator = zactor_new (autoconfig, (void*) AUTOCONFIG_NAME);
     if (set_verbose) {
-        zstr_sendx(ag_configurator, "VERBOSE", NULL);
+        zstr_sendx (ag_configurator, "VERBOSE", NULL);
     }
-    zstr_sendx(ag_configurator, "CONNECT", ENDPOINT, NULL);
-    zstr_sendx(ag_configurator, "TEMPLATES_DIR", "/usr/share/bios/fty-autoconfig", NULL);
-    zstr_sendx(ag_configurator, "CONSUMER", FTY_PROTO_STREAM_ASSETS, ".*", NULL);
-    zstr_sendx(ag_configurator, "ALERT_ENGINE_NAME", ENGINE_AGENT_NAME, NULL);
+    zstr_sendx (ag_configurator, "CONNECT", ENDPOINT, NULL);
+    zstr_sendx (ag_configurator, "TEMPLATES_DIR", "/usr/share/bios/fty-autoconfig", NULL);
+    zstr_sendx (ag_configurator, "CONSUMER", FTY_PROTO_STREAM_ASSETS, ".*", NULL);
+    zstr_sendx (ag_configurator, "ALERT_ENGINE_NAME", ENGINE_AGENT_NAME, NULL);
 
-    zactor_t *ag_actions = zactor_new(fty_alert_actions, (void*) ACTIONS_AGENT_NAME);
+    zactor_t *ag_actions = zactor_new (fty_alert_actions, (void*) ACTIONS_AGENT_NAME);
     if (set_verbose) {
-        zstr_sendx(ag_actions, "VERBOSE", NULL);
+        zstr_sendx (ag_actions, "VERBOSE", NULL);
     }
-    zstr_sendx(ag_actions, "CONNECT", ENDPOINT, NULL);
-    zstr_sendx(ag_actions, "CONSUMER", FTY_PROTO_STREAM_ASSETS, ".*", NULL);
-    zstr_sendx(ag_actions, "CONSUMER", FTY_PROTO_STREAM_ALERTS, ".*", NULL);
-    zstr_sendx(ag_actions, "ASKFORASSETS", NULL);
+    zstr_sendx (ag_actions, "CONNECT", ENDPOINT, NULL);
+    zstr_sendx (ag_actions, "CONSUMER", FTY_PROTO_STREAM_ASSETS, ".*", NULL);
+    zstr_sendx (ag_actions, "CONSUMER", FTY_PROTO_STREAM_ALERTS, ".*", NULL);
+    zstr_sendx (ag_actions, "ASKFORASSETS", NULL);
 
     //  Accept and print any message back from server
     //  copy from src/malamute.c under MPL license

--- a/src/fty_alert_engine_server.cc
+++ b/src/fty_alert_engine_server.cc
@@ -969,6 +969,7 @@ fty_alert_engine_server_test(
         zstr_free(&foo);
         zmsg_destroy(&recv);
     }
+
     // Test case #2.0: add new rule
     {
         zmsg_t *rule = zmsg_new();
@@ -988,6 +989,7 @@ fty_alert_engine_server_test(
         // does not make a sense to call streq on two json documents
         zmsg_destroy(&recv);
     }
+
     // Test case #2.1: add new rule
     {
         zmsg_t *rule = zmsg_new();
@@ -1167,6 +1169,7 @@ fty_alert_engine_server_test(
         assert(streq(fty_proto_state(brecv), "RESOLVED"));
         fty_proto_destroy(&brecv);
     }
+
     // Test case #2.2: add new rule with existing name
     {
         zmsg_t *rule = zmsg_new();
@@ -1189,6 +1192,7 @@ fty_alert_engine_server_test(
         // does not make a sense to call streq on two json documents
         zmsg_destroy(&recv);
     }
+
     // Test case #3: list rules
     {
         zmsg_t *command = zmsg_new();
@@ -1212,6 +1216,7 @@ fty_alert_engine_server_test(
         // does not make a sense to call streq on two json documents
         zmsg_destroy(&recv);
     }
+
     // Test case #4: list rules - not yet stored type
     {
         zmsg_t *command = zmsg_new();
@@ -1233,6 +1238,7 @@ fty_alert_engine_server_test(
         zstr_free(&foo);
         zmsg_destroy(&recv);
     }
+
     // Test case #4.1: list w/o rules
     {
         zmsg_t *command = zmsg_new();
@@ -1255,6 +1261,7 @@ fty_alert_engine_server_test(
         zstr_free(&foo);
         zmsg_destroy(&recv);
     }
+
     // Test case #13: segfault on onbattery
     // #13.1 ADD new rule
     {
@@ -1278,6 +1285,7 @@ fty_alert_engine_server_test(
                 NULL, ::time(NULL), ::time(NULL), "status.ups", "5PX1500-01", "1032.000", "");
         mlm_client_send(producer, "status.ups@5PX1500-01", &m);
     }
+
     // Test case #14: add new rule, but with lua syntax error
     {
         zsys_info("######## Test case #14 add new rule, but with lua syntax error");
@@ -1301,6 +1309,7 @@ fty_alert_engine_server_test(
         // does not make a sense to call streq on two json documents
         zmsg_destroy(&recv);
     }
+
     // Test case #15.1: add Radek's testing rule
     {
         zmsg_t *rule = zmsg_new();
@@ -1354,6 +1363,7 @@ fty_alert_engine_server_test(
         fty_proto_destroy(&brecv);
         zmsg_destroy(&recv);
     }
+
     // Test case #16.1: add new rule, with the trash at the end
     {
         zmsg_t *rule = zmsg_new();
@@ -1443,6 +1453,7 @@ fty_alert_engine_server_test(
         // does not make a sense to call streq on two json documents
         zmsg_destroy(&recv);
     }
+
     // ######## Test case #18
     // 18.1 add some rule (type: pattern)
     {
@@ -1513,6 +1524,7 @@ fty_alert_engine_server_test(
         zstr_free(&pattern_rule);
         zmsg_destroy(&recv);
     }
+
     // Test case #21:   Thresholds imported from devices
     {
         //      21.1.1  add existing rule: devicethreshold
@@ -1633,6 +1645,7 @@ fty_alert_engine_server_test(
         zstr_free(&foo);
         zmsg_destroy(&recv);
     }
+
     // test 23: touch rule, that doesn't exist
     {
         zmsg_t *touch_request = zmsg_new();
@@ -1652,6 +1665,7 @@ fty_alert_engine_server_test(
         zstr_free(&foo);
         zmsg_destroy(&recv);
     }
+
     // test 24: touch rule that exists
     {
         // 24.1 Create a rule we are going to test against
@@ -1779,6 +1793,7 @@ fty_alert_engine_server_test(
         }
         zpoller_destroy(&poller);
     }
+
     // test 25: metric_unavailable
     // 25.1 Create a rules we are going to test against; add First rule
     {
@@ -2143,6 +2158,7 @@ fty_alert_engine_server_test(
     zpoller_destroy (&poller);
     }
      */
+
     // Test case #20 update some rule (type: pattern)
     {
         zmsg_t *rule = zmsg_new();

--- a/src/templateruleconfigurator.cc
+++ b/src/templateruleconfigurator.cc
@@ -150,7 +150,7 @@ std::string TemplateRuleConfigurator::convertTypeSubType2Name(const char *type, 
     std::string name;
     std::string prefix ("__");
     std::string subtype_str (subtype);
-    if (subtype_str.empty () || (subtype_str == "unknown") || subtype_str == "N_A")
+    if (subtype_str.empty () || (subtype_str == "unknown") || (subtype_str == "N_A"))
         name = prefix + type + prefix;
     else
         name = prefix + type + '_' + subtype + prefix;


### PR DESCRIPTION
Solution: apply back (most of) whitespace markup from the previous codebase state, as it is what zproject generates and what we accept as project coding style

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>