### PR TITLE
For automation, we need to publish rule templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,10 @@ where
 The FTY-AUTOCONFIG-SERVER peer MUST respond with one of the messages back to USER
 peer using MAILBOX SEND.
 
-* 'correlation_id'/LIST/'filter'/'rule\-1'/.../'rule\-n'
+* 'correlation_id'/LIST/'filter'/
+    'template-name-1'/'template-1'/'device-iname-comma-separator-list-1'
+    ../../..
+    'template-name-n'/'template-n'/'device-iname-comma-separator-list-n'
 * 'correlation_id'/ERROR/'reason'
 
 where

--- a/README.md
+++ b/README.md
@@ -82,14 +82,15 @@ Actor fty-alert-engine server can be requested for:
 * touching rule (forces re-evaluation)
 * deleting rules
 
-Actor fty-autoconfig doesn't receive any mailbox requests.
+Actor fty-autoconfig server can be requested for:
+ * list of templates
 
 Actor fty-alert-actions doesn't receive any mailbox requests.
 
 #### List of rules
 
 The USER peer sends the following messages using MAILBOX SEND to
-FTY-ALERT-ENGINE-SERVER ("fty-alert-engine-server") peer:
+FTY-ALERT-ENGINE-SERVER ("fty-alert-engine") peer:
 
 * LIST/'type'\[/'ruleclass'\]
 
@@ -116,7 +117,7 @@ where
 #### Getting rule content
 
 The USER peer sends the following messages using MAILBOX SEND to
-FTY-ALERT-ENGINE-SERVER ("fty-alert-engine-server") peer:
+FTY-ALERT-ENGINE-SERVER ("fty-alert-engine") peer:
 
 * GET/'name'
 
@@ -140,7 +141,7 @@ where
 #### Adding new rule
 
 The USER peer sends the following messages using MAILBOX SEND to
-FTY-ALERT-ENGINE-SERVER ("fty-alert-engine-server") peer:
+FTY-ALERT-ENGINE-SERVER ("fty-alert-engine") peer:
 
 * ADD/'rule'
 
@@ -168,7 +169,7 @@ where
 #### Updating rule
 
 The USER peer sends the following messages using MAILBOX SEND to
-FTY-ALERT-ENGINE-SERVER ("fty-alert-engine-server") peer:
+FTY-ALERT-ENGINE-SERVER ("fty-alert-engine") peer:
 
 * ADD/'rule'/'old\-name'
 
@@ -198,7 +199,7 @@ where
 #### Touching rule
 
 The USER peer sends the following messages using MAILBOX SEND to
-FTY-ALERT-ENGINE-SERVER ("fty-alert-engine-server") peer:
+FTY-ALERT-ENGINE-SERVER ("fty-alert-engine") peer:
 
 * TOUCH/'name'
 
@@ -221,7 +222,7 @@ where
 #### Deleting rules
 
 To delete one particular rule, the USER peer sends the following messages using MAILBOX SEND to
-FTY-ALERT-ENGINE-SERVER ("fty-alert-engine-server") peer:
+FTY-ALERT-ENGINE-SERVER ("fty-alert-engine") peer:
 
 * DELETE/'name'
 
@@ -236,7 +237,7 @@ peer using MAILBOX SEND.
 * ERROR/reason
 
 To delete all rules about an element, the USER peer sends the following messages using MAILBOX SEND to
-FTY-ALERT-ENGINE-SERVER ("fty-alert-engine-server") peer:
+FTY-ALERT-ENGINE-SERVER ("fty-alert-engine") peer:
 
 * DELETE_ELEMENT/'name'
 
@@ -249,6 +250,32 @@ peer using MAILBOX SEND.
 
 * OK/rulename1/rulename2/...
 * ERROR/reason
+
+#### List of templates rules
+
+The USER peer sends the following messages using MAILBOX SEND to 
+FTY-AUTOCONFIG-SERVER ("fty-autoconfig") peer:
+
+* LIST/'correlation_id'/['filter']
+
+where
+* '/' indicates a multipart string message
+* 'filter' is a regex matching the content : typical regex are 'threshold','single','pattern'
+           "all" means return all templates. filter is optional, by default "all" is applied
+* subject of the message MUST be 'rfc-evaluator-rules'
+
+The FTY-AUTOCONFIG-SERVER peer MUST respond with one of the messages back to USER
+peer using MAILBOX SEND.
+
+* LIST/'correlation_id'/'filter'/'rule\-1'/.../'rule\-n'
+* ERROR/'correlation_id'/'reason'
+
+where
+* '/' indicates a multipart frame message
+* 'filter' MUST be copied from the request
+* 'rule\-1',...'rule\-n' MUST be JSONs corresponding to rules of given type and rule class
+* 'reason' is string detailing reason for error. Possible values are: INVALID\_FILTER
+* subject of the message MUST be 'rfc-evaluator-rules'
 
 ### Stream METRICS\_UNAVAILABLE
 

--- a/README.md
+++ b/README.md
@@ -267,8 +267,8 @@ where
 The FTY-AUTOCONFIG-SERVER peer MUST respond with one of the messages back to USER
 peer using MAILBOX SEND.
 
-* LIST/'correlation_id'/'filter'/'rule\-1'/.../'rule\-n'
-* ERROR/'correlation_id'/'reason'
+* 'correlation_id'/LIST/'filter'/'rule\-1'/.../'rule\-n'
+* 'correlation_id'/ERROR/'reason'
 
 where
 * '/' indicates a multipart frame message

--- a/include/autoconfig.h
+++ b/include/autoconfig.h
@@ -155,6 +155,7 @@ class Autoconfig {
         int _exitStatus = 0;
         int _timeout = 2000;
         std::string _agentName;
+        void listTemplates(const char *correlation_id, const char *type);
 };
 
 #endif

--- a/include/autoconfig.h
+++ b/include/autoconfig.h
@@ -24,6 +24,7 @@
 
 #include <map>
 #include <string>
+#include <list>
 #include <malamute.h>
 
 #define TIMEOUT 1000
@@ -155,6 +156,7 @@ class Autoconfig {
         int _exitStatus = 0;
         int _timeout = 2000;
         std::string _agentName;
+        std::list<std::string> getElemenListMatchTemplate(std::string template_name);
         void listTemplates(const char *correlation_id, const char *type);
 };
 

--- a/include/fty_alert_engine.h
+++ b/include/fty_alert_engine.h
@@ -26,5 +26,6 @@
 #include "fty_alert_engine_library.h"
 
 //  Add your own public definitions here, if you need them
+#define RULES_SUBJECT "rfc-evaluator-rules"
 
 #endif

--- a/src/autoconfig.cc
+++ b/src/autoconfig.cc
@@ -490,8 +490,8 @@ void Autoconfig::listTemplates(
     const char *myfilter=(filter==NULL?"all":filter);
     
     zmsg_t *reply = zmsg_new ();
-    zmsg_addstr (reply, "LIST");
     zmsg_addstr (reply, correlation_id);
+    zmsg_addstr (reply, "LIST");
     zmsg_addstr (reply, myfilter);
     
     cxxtools::Regex reg(myfilter, REG_EXTENDED);

--- a/src/autoconfig.cc
+++ b/src/autoconfig.cc
@@ -500,9 +500,9 @@ void Autoconfig::listTemplates(
         const char *filter
     )
 {
-    log_debug ("DO REQUEST LIST template '%s' correl_id '%s'",
-            (filter!=NULL?filter:"NA"),correlation_id);
     const char *myfilter=(filter==NULL?"all":filter);
+    log_debug ("DO REQUEST LIST template '%s' correl_id '%s'",
+            myfilter,correlation_id);
     
     zmsg_t *reply = zmsg_new ();
     zmsg_addstr (reply, correlation_id);

--- a/src/autoconfig.cc
+++ b/src/autoconfig.cc
@@ -34,6 +34,7 @@
 
 #include <cxxtools/jsonserializer.h>
 #include <cxxtools/jsondeserializer.h>
+#include <cxxtools/regex.h>
 
 #include <fty_common_filesystem.h>
 
@@ -269,10 +270,19 @@ void Autoconfig::main (zsock_t *pipe, char *name)
                             command (), subject (), sender ());
                 }
                 zstr_free (&reply);
+            }else{
+                char *cmd = zmsg_popstr (message);
+                if (streq (cmd, "LIST")) {
+                    char *correl_id = zmsg_popstr (message);
+                    char *filter = zmsg_popstr (message);
+                    listTemplates ( correl_id,filter);
+                    zstr_free (&correl_id);
+                    zstr_free (&filter);
+                }else
+                    log_warning ("Unexpected message received, command = '%s', subject = '%s', sender = '%s'",
+                            command (), subject (), sender ());
+                zstr_free (&cmd);
             }
-            else
-                log_warning ("Message from unknown sender received: sender = '%s', command = '%s', subject = '%s'.",
-                    sender (), command (), subject ());
             zmsg_destroy (&message);
         }
     }
@@ -468,6 +478,41 @@ void Autoconfig::saveState()
     serializer.finish();
     std::string json = stream.str();
     save_agent_info(json );
+}
+
+void Autoconfig::listTemplates(
+        const char *correlation_id,
+        const char *filter
+    )
+{
+    log_debug ("DO REQUEST LIST template '%s' correl_id '%s'",
+            (filter!=NULL?filter:"NA"),correlation_id);
+    const char *myfilter=(filter==NULL?"all":filter);
+    
+    zmsg_t *reply = zmsg_new ();
+    zmsg_addstr (reply, "LIST");
+    zmsg_addstr (reply, correlation_id);
+    zmsg_addstr (reply, myfilter);
+    
+    cxxtools::Regex reg(myfilter, REG_EXTENDED);
+
+    TemplateRuleConfigurator templateRuleConfigurator;
+    std::vector <std::pair<std::string,std::string>> 
+            templates = templateRuleConfigurator.loadAllTemplates();
+    log_debug ("number of total templates rules = '%zu'", templates.size ());
+    int count=0;
+    for (const auto &templat : templates) {
+        if (!streq (myfilter, "all") && !reg.match (templat.second) ) {
+            log_trace ("templates '%s' does not match", templat.first.c_str());
+            continue;
+        }
+        log_trace ("templates '%s' match", templat.first.c_str());
+        zmsg_addstr (reply, templat.second.c_str());
+        count++;
+    }
+    log_debug ("%zu templates match '%s'", count, myfilter);
+    mlm_client_sendto (_client, sender(), RULES_SUBJECT,
+            mlm_client_tracker(_client), 1000, &reply);
 }
 
 void autoconfig (zsock_t *pipe, void *args )

--- a/src/fty_alert_engine_server.cc
+++ b/src/fty_alert_engine_server.cc
@@ -2351,8 +2351,11 @@ fty_alert_engine_server_test(
                 std::string str((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
                 template_name = zmsg_popstr (recv);
                 assert(fn.compare(template_name)==0);
+                //template content
                 foo = zmsg_popstr (recv);
                 assert(str.compare(foo)==0);
+                zstr_free (&foo);
+                //element list
                 foo = zmsg_popstr (recv);
                 if(fn.find("__row__")!= std::string::npos){
                     log_debug("template: '%s', devices :'%s'",template_name,foo);

--- a/src/fty_alert_engine_server.cc
+++ b/src/fty_alert_engine_server.cc
@@ -36,9 +36,9 @@
 #include <algorithm>
 #include <mutex>
 #include <unordered_map>
+#include <cxxtools/directory.h>
 
 #define METRICS_STREAM "METRICS"
-#define RULES_SUBJECT "rfc-evaluator-rules"
 
 #include "fty_alert_engine_classes.h"
 
@@ -2067,7 +2067,7 @@ fty_alert_engine_server_test(
         mlm_client_destroy (&metric_unavailable);
     }
 
-    // # 26 - # 29 : test autoconfig
+    // # 26 - # 30 : test autoconfig
     mlm_client_t *asset_producer = mlm_client_new ();
     mlm_client_connect (asset_producer, endpoint, 1000, "asset_producer");
     mlm_client_set_producer (asset_producer, FTY_PROTO_STREAM_ASSETS);
@@ -2320,6 +2320,43 @@ fty_alert_engine_server_test(
     zpoller_destroy (&poller);
     }
      */
+    // Test case #30: list templates rules
+    {
+        zmsg_t *command = zmsg_new ();
+        zmsg_addstrf (command, "%s", "LIST");
+        zmsg_addstrf (command, "%s", "123456");
+        zmsg_addstrf (command, "%s", "all");
+        mlm_client_sendto (ui, "test-autoconfig", "rfc-evaluator-rules", NULL, 1000, &command);
+
+        zmsg_t *recv = mlm_client_recv (ui);
+
+        char *foo = zmsg_popstr (recv);
+        assert (streq (foo, "LIST"));
+        zstr_free (&foo);
+        foo = zmsg_popstr (recv);
+        assert (streq (foo, "123456"));
+        zstr_free (&foo);
+        foo = zmsg_popstr (recv);
+        assert (streq (foo, "all"));
+        zstr_free (&foo);
+        
+        cxxtools::Directory d((str_SELFTEST_DIR_RO + "/templates").c_str());
+        int file_counter=0;
+        for ( const auto &fn : d) {
+            if ( fn.compare(".")!=0  && fn.compare("..")!=0){
+                // read the template rule from the file
+                std::ifstream f(d.path() + "/" + fn);
+                std::string str((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+                foo = zmsg_popstr (recv);
+                assert(str.compare(foo)==0);
+                file_counter++;
+                zstr_free (&foo);
+            }
+        }
+        assert(file_counter>0);
+        log_debug("Test #30 : List All templates parse successfully %d files",file_counter);
+        zmsg_destroy (&recv);
+    }
 
     // Test case #20 update some rule (type: pattern)
     {

--- a/src/fty_alert_engine_server.cc
+++ b/src/fty_alert_engine_server.cc
@@ -2322,6 +2322,7 @@ fty_alert_engine_server_test(
      */
     // Test case #30: list templates rules
     {
+        log_debug("Test #30 ..");
         zmsg_t *command = zmsg_new ();
         zmsg_addstrf (command, "%s", "LIST");
         zmsg_addstrf (command, "%s", "123456");
@@ -2342,15 +2343,24 @@ fty_alert_engine_server_test(
         
         cxxtools::Directory d((str_SELFTEST_DIR_RO + "/templates").c_str());
         int file_counter=0;
+        char *template_name;
         for ( const auto &fn : d) {
             if ( fn.compare(".")!=0  && fn.compare("..")!=0){
                 // read the template rule from the file
                 std::ifstream f(d.path() + "/" + fn);
                 std::string str((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+                template_name = zmsg_popstr (recv);
+                assert(fn.compare(template_name)==0);
                 foo = zmsg_popstr (recv);
                 assert(str.compare(foo)==0);
+                foo = zmsg_popstr (recv);
+                if(fn.find("__row__")!= std::string::npos){
+                    log_debug("template: '%s', devices :'%s'",template_name,foo);
+                    assert(streq (foo,"test"));
+                }
                 file_counter++;
                 zstr_free (&foo);
+                zstr_free (&template_name);
             }
         }
         assert(file_counter>0);

--- a/src/fty_alert_engine_server.cc
+++ b/src/fty_alert_engine_server.cc
@@ -2331,10 +2331,10 @@ fty_alert_engine_server_test(
         zmsg_t *recv = mlm_client_recv (ui);
 
         char *foo = zmsg_popstr (recv);
-        assert (streq (foo, "LIST"));
+        assert (streq (foo, "123456"));
         zstr_free (&foo);
         foo = zmsg_popstr (recv);
-        assert (streq (foo, "123456"));
+        assert (streq (foo, "LIST"));
         zstr_free (&foo);
         foo = zmsg_popstr (recv);
         assert (streq (foo, "all"));

--- a/src/templateruleconfigurator.cc
+++ b/src/templateruleconfigurator.cc
@@ -113,6 +113,30 @@ TemplateRuleConfigurator::isModelOk (const std::string& model,
 bool TemplateRuleConfigurator::isApplicable (const AutoConfigurationInfo& info){
     return checkTemplate(info.type.c_str (), info.subtype.c_str ());
 }
+bool TemplateRuleConfigurator::isApplicable (const AutoConfigurationInfo& info, 
+        const std::string& templat_name)
+{
+
+    cxxtools::Directory d(Autoconfig::RuleFilePath);
+    std::ifstream f(d.path() + "/" + templat_name);
+    if(!f.good())return false;
+    
+    std::string type_name = convertTypeSubType2Name(info.type.c_str(),info.subtype.c_str());
+    if ( templat_name.find(type_name.c_str())!= std::string::npos){
+        if(info.subtype == "sensorgpio" && info.attributes.find("model") != info.attributes.end()){
+            std::string model=info.attributes.find("model")->second;
+            //for sensor gpio,we need to parse the template content to check model
+            std::string templat_content((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+            if (templat_content.find(model) != std::string::npos)
+                return true;
+            else
+                return false;
+        }
+        return true;
+    }
+    return false;
+    
+}
 
 std::vector <std::string> TemplateRuleConfigurator::loadTemplates(const char *type, const char *subtype){
     std::vector <std::string> templates;
@@ -177,8 +201,8 @@ std::string TemplateRuleConfigurator::convertTypeSubType2Name(const char *type, 
         name = prefix + type + prefix;
     else
         name = prefix + type + '_' + subtype + prefix;
-    log_debug("convertTypeSubType2Name(info.type = '%s', info.subtype = '%s') = '%s')",
-            type, subtype,name.c_str());
+    //log_trace("convertTypeSubType2Name(info.type = '%s', info.subtype = '%s') = '%s')",
+    //        type, subtype,name.c_str());
     return name;
 }
 

--- a/src/templateruleconfigurator.cc
+++ b/src/templateruleconfigurator.cc
@@ -134,6 +134,24 @@ std::vector <std::string> TemplateRuleConfigurator::loadTemplates(const char *ty
     return templates;
 }
 
+std::vector <std::pair<std::string,std::string>> TemplateRuleConfigurator::loadAllTemplates(){
+    std::vector <std::pair<std::string,std::string>> templates;
+    if (!cxxtools::Directory::exists (Autoconfig::RuleFilePath.c_str ())){
+        log_info("TemplateRuleConfigurator '%s' dir does not exist",Autoconfig::RuleFilePath.c_str ());
+        return templates;
+    }
+    cxxtools::Directory d(Autoconfig::RuleFilePath);
+    for ( const auto &fn : d) {
+        if ( fn.compare(".")!=0  && fn.compare("..")!=0){
+            // read the template rule from the file
+            std::ifstream f(d.path() + "/" + fn);
+            std::string str((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+            templates.push_back(std::make_pair(fn,str));
+        }
+    }
+    return templates;
+}
+
 bool TemplateRuleConfigurator::checkTemplate(const char *type, const char *subtype){
     if (!cxxtools::Directory::exists (Autoconfig::RuleFilePath)){
         log_warning("TemplateRuleConfigurator '%s' dir does not exist",Autoconfig::RuleFilePath.c_str ());

--- a/src/templateruleconfigurator.h
+++ b/src/templateruleconfigurator.h
@@ -35,7 +35,7 @@ class TemplateRuleConfigurator : public RuleConfigurator {
                         const std::string &logical_asset,
                         mlm_client_t *client);
         bool isApplicable (const AutoConfigurationInfo& info);
-
+        std::vector <std::pair<std::string,std::string>>  loadAllTemplates();
         virtual ~TemplateRuleConfigurator() {};
     private:
         bool checkTemplate(const char *type, const char *subtype);

--- a/src/templateruleconfigurator.h
+++ b/src/templateruleconfigurator.h
@@ -35,6 +35,7 @@ class TemplateRuleConfigurator : public RuleConfigurator {
                         const std::string &logical_asset,
                         mlm_client_t *client);
         bool isApplicable (const AutoConfigurationInfo& info);
+        bool isApplicable (const AutoConfigurationInfo& info, const std::string& templat_name);
         std::vector <std::pair<std::string,std::string>>  loadAllTemplates();
         virtual ~TemplateRuleConfigurator() {};
     private:
@@ -45,7 +46,7 @@ class TemplateRuleConfigurator : public RuleConfigurator {
                                    const std::vector <std::string> &patterns,
                                    const std::vector <std::string> &replacements) const;
         bool isModelOk (const std::string &model, const std::string &templat);
-
+        
 };
 
 #endif


### PR DESCRIPTION
Signed-off-by: Gerald Guillaume <geraldguillaume@eaton.com>
As example :
bmsg request fty-autoconfig rfc-evaluator-rules LIST 12345 "threshold|flexible" 
will returns the list of threshold and flexible templates known in /usr/share/bios/fty-autoconfig

