### PR TITLE
Add rule internal-failure@__device_ups__.rule

### DIFF
--- a/src/Makemodule-local.am
+++ b/src/Makemodule-local.am
@@ -44,7 +44,8 @@ RULE_TEMPLATES = \
 	src/rule_templates/vibration-sensor.state-change@__device_sensorgpio__.rule \
 	src/rule_templates/water-leak-detector.state-change@__device_sensorgpio__.rule \
 	src/rule_templates/smoke-detector.state-change@__device_sensorgpio__.rule \
-	src/rule_templates/pir-motion-detector.state-change@__device_sensorgpio__.rule
+	src/rule_templates/pir-motion-detector.state-change@__device_sensorgpio__.rule \
+	src/rule_templates/internal-failure@__device_ups__.rule
 
 template_rule_DATA =	$(RULE_TEMPLATES)
 EXTRA_DIST +=		$(RULE_TEMPLATES)

--- a/src/rule_templates/internal-failure@__device_ups__.rule
+++ b/src/rule_templates/internal-failure@__device_ups__.rule
@@ -6,7 +6,7 @@
         "element"       :   "__name__",
         "values"        :   [ ],
         "results"       :   [
-            {"high_critical"  : { "action" : [{ "action": "EMAIL" },{ "action": "SMS" }], "severity" : "CRITICAL", "description" : "{\"key\" : \"TRANSLATE_LUA(UPS $ename$ has an internal failure!)\", \"variable\" : {\"ename\" : \"__ename__\"} }" }} ],
+            {"high_critical"  : { "action" : [], "severity" : "CRITICAL", "description" : "{\"key\" : \"TRANSLATE_LUA(UPS $ename$ has an internal failure.)\", \"variable\" : {\"ename\" : \"__ename__\"} }" }} ],
         "evaluation"    : "function has_bit(x,bit) local mask = 2 ^ (bit - 1); x = x % (2*mask); if x >= mask then return true else return false end end; function main(status,alarm) if has_bit(status,15) and (has_bit(alarm,3) or has_bit(alarm,7) or has_bit(alarm,9)) then return HIGH_CRITICAL end return OK end"
     }
 }

--- a/src/rule_templates/internal-failure@__device_ups__.rule
+++ b/src/rule_templates/internal-failure@__device_ups__.rule
@@ -7,6 +7,6 @@
         "values"        :   [ ],
         "results"       :   [
             {"high_critical"  : { "action" : [], "severity" : "CRITICAL", "description" : "{\"key\" : \"TRANSLATE_LUA(UPS $ename$ has an internal failure.)\", \"variable\" : {\"ename\" : \"__ename__\"} }" }} ],
-        "evaluation"    : "function has_bit(x,bit) local mask = 2 ^ (bit - 1); x = x % (2*mask); if x >= mask then return true else return false end end; function main(status,alarm) if has_bit(status,15) and (has_bit(alarm,3) or has_bit(alarm,7) or has_bit(alarm,9) or has_bit(alarm, 14)) then return HIGH_CRITICAL end return OK end"
+        "evaluation"    : "function has_bit(x,bit) local mask = 2 ^ (bit - 1); x = x % (2*mask); if x >= mask then return true else return false end end; function main(status,alarm) if has_bit(status,15) and has_bit(alarm,9) then return HIGH_CRITICAL end return OK end"
     }
 }

--- a/src/rule_templates/internal-failure@__device_ups__.rule
+++ b/src/rule_templates/internal-failure@__device_ups__.rule
@@ -7,6 +7,6 @@
         "values"        :   [ ],
         "results"       :   [
             {"high_critical"  : { "action" : [], "severity" : "CRITICAL", "description" : "{\"key\" : \"TRANSLATE_LUA(UPS $ename$ has an internal failure.)\", \"variable\" : {\"ename\" : \"__ename__\"} }" }} ],
-        "evaluation"    : "function has_bit(x,bit) local mask = 2 ^ (bit - 1); x = x % (2*mask); if x >= mask then return true else return false end end; function main(status,alarm) if has_bit(status,15) and (has_bit(alarm,3) or has_bit(alarm,7) or has_bit(alarm,9)) then return HIGH_CRITICAL end return OK end"
+        "evaluation"    : "function has_bit(x,bit) local mask = 2 ^ (bit - 1); x = x % (2*mask); if x >= mask then return true else return false end end; function main(status,alarm) if has_bit(status,15) and (has_bit(alarm,3) or has_bit(alarm,7) or has_bit(alarm,9) or has_bit(alarm, 14)) then return HIGH_CRITICAL end return OK end"
     }
 }

--- a/src/rule_templates/internal-failure@__device_ups__.rule
+++ b/src/rule_templates/internal-failure@__device_ups__.rule
@@ -1,0 +1,12 @@
+{
+    "single" : {
+        "rule_name"     :   "internal-failure@__name__",
+        "rule_class"    :   "TRANSLATE_LUA(UPS has an internal failure)",
+        "target"        :   ["status.ups@__name__", "ups.alarm@__name__"],
+        "element"       :   "__name__",
+        "values"        :   [ ],
+        "results"       :   [
+            {"high_critical"  : { "action" : [{ "action": "EMAIL" },{ "action": "SMS" }], "severity" : "CRITICAL", "description" : "{\"key\" : \"TRANSLATE_LUA(UPS $ename$ has an internal failure!)\", \"variable\" : {\"ename\" : \"__ename__\"} }" }} ],
+        "evaluation"    : "function has_bit(x,bit) local mask = 2 ^ (bit - 1); x = x % (2*mask); if x >= mask then return true else return false end end; function main(status,alarm) if has_bit(status,15) and (has_bit(alarm,3) or has_bit(alarm,7) or has_bit(alarm,9)) then return HIGH_CRITICAL end return OK end"
+    }
+}


### PR DESCRIPTION
Alarm is set to go off on the following alarm bits set:
* fan failure,
* battery charger fail,
* internal UPS fault.

Depends on 42ity/fty-nut#169 to work.