### PR TITLE
(XS/S) Use TRANSLATE_LUA instead of TRANSLATE_ME in a warranty rule.

### DIFF
--- a/src/warranty.rule
+++ b/src/warranty.rule
@@ -6,8 +6,8 @@
         "values_unit": "days",
         "results"       :   [
                                 {"high_critical"  : { "action" : [{ "action": "EMAIL" }], "description" : "{\"key\":\"TRANSLATE_LUA (Warranty expired)\"}", "threshold_name" : "TRANSLATE_LUA (Warranty expired)"}},
-                                {"low_critical"  : { "action" : [{ "action": "EMAIL" }], "description" : "{\"key\":\"TRANSLATE_ME (Warranty expires in)\"}", "threshold_name" : "TRANSLATE_ME (Warranty expires in)"}},
-                                {"low_warning"  : { "action" : [{ "action": "EMAIL" }], "description" : "{\"key\":\"TRANSLATE_ME (Warranty expires in)\"}", "threshold_name" : "TRANSLATE_ME (Warranty expires in)"}}
+                                {"low_critical"  : { "action" : [{ "action": "EMAIL" }], "description" : "{\"key\":\"TRANSLATE_LUA (Warranty expires in)\"}", "threshold_name" : "TRANSLATE_LUA (Warranty expires in)"}},
+                                {"low_warning"  : { "action" : [{ "action": "EMAIL" }], "description" : "{\"key\":\"TRANSLATE_LUA (Warranty expires in)\"}", "threshold_name" : "TRANSLATE_LUA (Warranty expires in)"}}
                             ],
         "evaluation"    : "function main(value) if( value < high_critical ) then return HIGH_CRITICAL end if( value <= low_critical ) then return LOW_CRITICAL end if ( value <= low_warning ) then return LOW_WARNING end return OK end"
     }


### PR DESCRIPTION
Signed-off-by: Jana Rapava <janarapava@eaton.com>