### PR TITLE
[backport 1.5.0] Problem : update simple threshold rule accept bad results array

### DIFF
--- a/src/rule.cc
+++ b/src/rule.cc
@@ -182,6 +182,10 @@ void operator>>= (const cxxtools::SerializationInfo& si, std::map <std::string, 
                     {"high_critical" : { "action" : [{ "action": "EMAIL"}], "description" : "wow high critical DESCTIPRION" } } ]
     */
     for ( const auto &oneElement : si ) { // iterate through the array
+        //we should ensure that only one member is present
+        if(oneElement.memberCount()!=1){
+            throw std::runtime_error ("unexpected member count element in results");
+        }
         auto outcomeName = oneElement.getMember(0).name();
         Outcome outcome;
         oneElement.getMember(0) >>= outcome;


### PR DESCRIPTION
Signed-off-by: Gerald Guillaume <geraldguillaume@eaton.com>
(cherry picked from commit 090466b622dd9a0b05adeddcc2b4d191a41f7ce0)

Problem :
fty-alert_engine accepts to update a threshold simple rule with a malformed results array.
some result may twiced.

Solution : ensure that the member count is 1