### PR TITLE
[backport 1.5.0] Problem: DCS variables is not replaced by its values

### DIFF
--- a/src/rule_templates/door-contact.state-change@__device_sensorgpio__.rule
+++ b/src/rule_templates/door-contact.state-change@__device_sensorgpio__.rule
@@ -1,7 +1,7 @@
 { 
     "flexible" : {
         "name"          : "door-contact.state-change@__name__",
-        "description"   : "{\"key\" : \"TRANSLATE_LUA(Door to {{logicalasset}} is not {{normalstate}})\", \"variables\" : {\"logical_asset\" : \"__logicalasset__\", \"normal_state\" : \"__normal_state__\"}}",
+        "description"   : "{\"key\" : \"TRANSLATE_LUA(Door to {{logical_asset}} is not {{normal_state}})\", \"variables\" : {\"logical_asset\" : \"__logicalasset__\", \"normal_state\" : \"__normalstate__\"}}",
         "rule_cat"      : ["CAT_GPIO", "CAT_ALL"],
         "metrics"       : ["status.__port__"],
         "assets"	    : ["__name__"],


### PR DESCRIPTION
Solution: Fix variable mispelling

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>
(cherry picked from commit 9fa9836132db5ae11a0c17469b96b180ebe2d59c)