### PR TITLE
Problem: Rules contain TRANSLATE_LUA, not TRANSLATE_ME.

### DIFF
--- a/src/fty_alert_engine_server.cc
+++ b/src/fty_alert_engine_server.cc
@@ -534,7 +534,7 @@ evaluate_metric (
                         std::string ("{\"key\" : \"TRANSLATE_LUA (Warranty on {{asset}} expired {{days}} days ago.)\", ") +
                         "\"variables\" : { \"asset\" : { \"value\" : \"\", \"assetLink\" : \"" +
                         triggeringMetric.getElementName () + "\" }, \"days\" : \"" + std::to_string (remaining_days) + "\"} }";
-                } else if (alertToSend._description == "{\"key\":\"TRANSLATE_ME (Warranty expires in)\"}") {
+                } else if (alertToSend._description == "{\"key\":\"TRANSLATE_LUA (Warranty expires in)\"}") {
                     alertToSend._description =
                         std::string ("{\"key\" : \"TRANSLATE_LUA (Warranty on {{asset}} expires in less than {{days}} days.)\", ") +
                         "\"variables\" : { \"asset\" : { \"value\" : \"\", \"assetLink\" : \"" +


### PR DESCRIPTION
Solution: Use correct string for matching.

Signed-off-by: Jana Rapava <janarapava@eaton.com>
(cherry picked from commit c64045a77c01470419a60b4c4fc4bdca06ecbfb1)
Signed-off-by: Jana Rapava <janarapava@eaton.com>

Conflicts:
	src/fty_alert_engine_server.cc