### PR TITLE
Problem: sensor rules are missing in /usr/share/bios/fty-autoconfig

### DIFF
--- a/src/Makemodule-local.am
+++ b/src/Makemodule-local.am
@@ -45,7 +45,9 @@ RULE_TEMPLATES = \
 	src/rule_templates/water-leak-detector.state-change@__device_sensorgpio__.rule \
 	src/rule_templates/smoke-detector.state-change@__device_sensorgpio__.rule \
 	src/rule_templates/pir-motion-detector.state-change@__device_sensorgpio__.rule \
-	src/rule_templates/internal-failure@__device_ups__.rule
+	src/rule_templates/internal-failure@__device_ups__.rule \
+	src/rule_templates/humidity.default@__device_sensor__.rule \
+	src/rule_templates/temperature.default@__device_sensor__.rule
 
 template_rule_DATA =	$(RULE_TEMPLATES)
 EXTRA_DIST +=		$(RULE_TEMPLATES)


### PR DESCRIPTION
Solution:
Update Makemodule-local.am, add __device_sensor__ rules in RULE_TEMPLATES
