### PR TITLE
Update Makemodule-local.am

### DIFF
--- a/src/Makemodule-local.am
+++ b/src/Makemodule-local.am
@@ -50,8 +50,7 @@ RULE_TEMPLATES = \
 	src/rule_templates/pir-motion-detector.state-change@__device_sensorgpio__.rule \
 	src/rule_templates/internal-failure@__device_ups__.rule \
 	src/rule_templates/humidity.default@__device_sensor__.rule \
-	src/rule_templates/temperature.default@__device_sensor__.rule \
-	src/rule_templates/single-point-of-failure@__device_ups__.rule
+	src/rule_templates/temperature.default@__device_sensor__.rule
 
 template_rule_DATA =	$(RULE_TEMPLATES)
 EXTRA_DIST +=		$(RULE_TEMPLATES)


### PR DESCRIPTION
The powerchain analysis service handle now SPoF alarms internally.
spof alarm rule is now obsolete, and should be removed.