### PR TITLE
Fix internal-failure@__device_ups__.rule

### DIFF
--- a/src/rule_templates/internal-failure@__device_ups__.rule
+++ b/src/rule_templates/internal-failure@__device_ups__.rule
@@ -7,7 +7,7 @@
         "element"       :   "__name__",
         "values"        :   [ ],
         "results"       :   [
-            {"high_critical"  : { "action" : [], "severity" : "CRITICAL", "description" : "{\"key\" : \"TRANSLATE_LUA(UPS {{ename}} has an internal failure.)\", \"variable\" : {\"ename\" : \"__ename__\"} }" }} ],
+            {"high_critical"  : { "action" : [], "severity" : "CRITICAL", "description" : "{\"key\" : \"TRANSLATE_LUA(UPS {{ename}} has an internal failure.)\", \"variables\" : {\"ename\" : \"__ename__\"} }" }} ],
         "evaluation"    : "function has_bit(x,bit) local mask = 2 ^ (bit - 1); x = x % (2*mask); if x >= mask then return true else return false end end; function main(status,alarm) if has_bit(status,15) and has_bit(alarm,9) then return HIGH_CRITICAL end return OK end"
     }
 }


### PR DESCRIPTION
Fix 'variables' token typo on internal-failure@__device_ups__.rule