### PR TITLE
ignore just total power

### DIFF
--- a/src/templateruleconfigurator.cc
+++ b/src/templateruleconfigurator.cc
@@ -32,6 +32,7 @@
 #include <cxxtools/directory.h>
 #include "templateruleconfigurator.h"
 #include "autoconfig.h"
+#include <regex>
 
 bool
 TemplateRuleConfigurator::configure (
@@ -85,12 +86,12 @@ TemplateRuleConfigurator::configure (
             {
                 if (!TemplateRuleConfigurator::isModelOk (model, templat))
                 {
-                    log_debug("Skip rule for gpio:\n %s", rule.c_str());
+                    log_debug("Skip rule for gpio:\n %s", name.c_str());
                     continue;
                 }
                 else
                 {
-                    log_debug("Ready to send rule for gpio:\n %s", rule.c_str());
+                    log_debug("Ready to send rule for gpio:\n %s", name.c_str());
                 }
             }
 
@@ -100,7 +101,7 @@ TemplateRuleConfigurator::configure (
             //In fast track mode we skip dc realpower rules
             if(fast_track)
             {
-                if(std::regex_match(rule, std::regex(.*\"power\\.realpower\\.default\\.dc\".*")))
+                if(std::regex_match(rule, std::regex(".*\"power\\.realpower\\.default\\.dc\".*")))
                 {
                     log_debug("Fast track mode skip rules:\n %s", rule.c_str());
                     continue;

--- a/src/templateruleconfigurator.h
+++ b/src/templateruleconfigurator.h
@@ -40,13 +40,13 @@ class TemplateRuleConfigurator : public RuleConfigurator {
         virtual ~TemplateRuleConfigurator() {};
     private:
         bool checkTemplate(const char *type, const char *subtype);
-        std::vector <std::string> loadTemplates(const char *type, const char *subtype);
+        std::vector <std::string> loadTemplates(const char *type, const char *subtype, bool fast_track = false);
         std::string convertTypeSubType2Name(const char *type, const char *subtype);
         std::string replaceTokens( const std::string &text,
                                    const std::vector <std::string> &patterns,
                                    const std::vector <std::string> &replacements) const;
         bool isModelOk (const std::string &model, const std::string &templat);
-        
+
 };
 
 #endif


### PR DESCRIPTION
Instead of ignoring all the alert rules creation in fast track mode, we disable only the realpower