### PR TITLE
Metric memory optimization and misc

### DIFF
--- a/src/alertconfiguration.h
+++ b/src/alertconfiguration.h
@@ -87,10 +87,12 @@ public:
     {
         return _alerts_map.end();
     }
+
     size_t size()
     {
         return _alerts_map.size();
     }
+
     B& at(std::string name)
     {
         return _alerts_map.at(name);
@@ -192,16 +194,12 @@ public:
 
     int deleteAllRules(const std::string& element, std::map<std::string, std::vector<PureAlert>>& alertsToSend);
 
-    int deleteRules(RuleMatcher* matcher, std::map<std::string, std::vector<PureAlert>>& alertsToSend,
-        std::vector<std::string>& rulesDeleted);
+    int deleteRules(RuleMatcher* matcher, std::map<std::string, std::vector<PureAlert>>& alertsToSend, std::vector<std::string>& rulesDeleted);
 
     const std::vector<std::string> getRulesByMetric(const std::string& metric)
     {
         const auto& it = _metrics_alerts_map.find(metric);
-        if (it != _metrics_alerts_map.cend()) {
-            return it->second;
-        }
-        return {};
+        return ((it != _metrics_alerts_map.cend()) ? it->second : std::vector<std::string>{});
     }
 
 private:

--- a/src/alertconfiguration.h
+++ b/src/alertconfiguration.h
@@ -174,17 +174,16 @@ public:
     bool haveRule(const RulePtr& rule) const
     {
         return haveRule(rule->name());
-    };
+    }
 
     bool haveRule(const std::string& rule_name) const
     {
-        const auto& i = _alerts_map.find(rule_name);
-        return (i != _alerts_map.end());
-    };
+        return (_alerts_map.find(rule_name) != _alerts_map.end());
+    }
 
     int updateAlertState(const char* rule_name, const char* element_name, const char* new_state, PureAlert& pureAlert);
 
-    std::string getPersistencePath(void) const
+    std::string getPersistencePath() const
     {
         return _path + '/';
     }
@@ -196,14 +195,13 @@ public:
     int deleteRules(RuleMatcher* matcher, std::map<std::string, std::vector<PureAlert>>& alertsToSend,
         std::vector<std::string>& rulesDeleted);
 
-    const std::vector<std::string> getRulesByMetric(std::string metric)
+    const std::vector<std::string> getRulesByMetric(const std::string& metric)
     {
-        auto it = _metrics_alerts_map.find(metric);
-        if (it == _metrics_alerts_map.end())
-            return std::vector<std::string>{};
-        else
+        const auto& it = _metrics_alerts_map.find(metric);
+        if (it != _metrics_alerts_map.cend()) {
             return it->second;
-        // return std::vector<std::string>(it->second);
+        }
+        return {};
     }
 
 private:

--- a/src/fty_alert_engine.cc
+++ b/src/fty_alert_engine.cc
@@ -23,7 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <czmq.h>
 
 static const char* CONFIG = "/etc/fty-alert-engine/fty-alert-engine.cfg";
-// path to the directory, where rules are stored. CAUTION: **without** last slash!
+// path to the directory, where rules are stored. CAUTION: **without** ending slash!
 static const char* PATH = "/var/lib/fty/fty-alert-engine";
 
 // agents name

--- a/src/fty_alert_engine.cc
+++ b/src/fty_alert_engine.cc
@@ -23,7 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <czmq.h>
 
 static const char* CONFIG = "/etc/fty-alert-engine/fty-alert-engine.cfg";
-// path to the directory, where rules are stored. Attention: without last slash!
+// path to the directory, where rules are stored. CAUTION: **without** last slash!
 static const char* PATH = "/var/lib/fty/fty-alert-engine";
 
 // agents name
@@ -43,30 +43,31 @@ int main(int argc, char** argv)
 
     ManageFtyLog::setInstanceFtylog(ENGINE_AGENT_NAME, FTY_COMMON_LOGGING_DEFAULT_CFG);
 
-    int argn;
-    for (argn = 1; argn < argc; argn++) {
-        char* par = NULL;
-        if (argn < argc - 1)
-            par = argv[argn + 1];
+    for (int argn = 1; argn < argc; argn++) {
+        char* arg = argv[argn];
+        char* par = (argn < (argc - 1)) ? argv[argn + 1] : NULL;
 
-        if (streq(argv[argn], "-v") || streq(argv[argn], "--verbose")) {
+        if (streq(arg, "-v") || streq(arg, "--verbose")) {
             ManageFtyLog::getInstanceFtylog()->setVerboseMode();
         }
-        else if (streq(argv[argn], "-h") || streq(argv[argn], "--help")) {
+        else if (streq(arg, "-h") || streq(arg, "--help")) {
             puts("fty-alert-engine [option] [value]");
             puts("   -v|--verbose          verbose output");
             puts("   -h|--help             print help");
             puts("   -c|--config [path]    use custom config file ");
-            return 0;
+            return EXIT_SUCCESS;
         }
-        else if (streq(argv[argn], "-c") || streq(argv[argn], "--config")) {
-            if (par)
-                config = zconfig_load(par);
-            ++argn;
+        else if (streq(arg, "-c") || streq(arg, "--config")) {
+            if (!par) {
+                printf("Missing parameter: %s, run with -h|--help \n", arg);
+                return EXIT_FAILURE;
+            }
+            config = zconfig_load(par);
+            argn++;
         }
         else {
-            printf("Unknown option: %s, run with -h|--help \n", argv[argn]);
-            return 1;
+            printf("Unknown option: %s, run with -h|--help \n", arg);
+            return EXIT_FAILURE;
         }
     }
 
@@ -133,5 +134,5 @@ int main(int argc, char** argv)
     // release audit context
     AuditLogManager::deinit();
 
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/src/metricinfo.h
+++ b/src/metricinfo.h
@@ -63,6 +63,6 @@ private:
     std::string _element_name; /// asset iname
     std::string _source; /// metric type
     double      _value{0};
-    uint64_t    _timestamp{0}; /// last update (epoch time, sec.)
+    uint64_t    _timestamp{0}; /// latest update (epoch time, sec.)
     uint64_t    _ttl{0}; /// time to live (sec)
 };

--- a/src/metricinfo.h
+++ b/src/metricinfo.h
@@ -18,105 +18,51 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 /// @file metricinfo.h
 /// @author Alena Chernikava <AlenaChernikava@Eaton.com>
-/// @brief Very simple class to store information about one metric
+/// @brief Class to store information about one metric
+
 #pragma once
+
 #include <string>
-#include <ctime>
+#include <cstdint>
 
 class MetricInfo
 {
-
 public:
-    std::string generateTopic(void) const
-    {
-        return _source + "@" + _element_name;
-    };
+    MetricInfo() = default;
 
-    MetricInfo()
-        : _value{0}
-        , _timestamp{0}
-        , _ttl{5 * 60} {};
-
-    MetricInfo(const std::string& element_name, const std::string& source, const std::string& units, double value,
-        uint64_t timestamp, const std::string& destination, uint64_t ttl)
-        : _element_name(element_name)
-        , _source(source)
-        , _units(units)
+    MetricInfo(
+        const std::string& element_name,
+        const std::string& source,
+        double value,
+        uint64_t timestamp,
+        uint64_t ttl
+    )
+        : _element_name(element_name) // asset iname
+        , _source(source) // metric type
         , _value(value)
         , _timestamp(timestamp)
-        , _element_destination_name(destination)
-        , _ttl(ttl){};
+        , _ttl(ttl)
+    {}
 
-    double getValue(void) const
-    {
-        return _value;
-    };
+    /// accessors
+    std::string getElementName() const { return _element_name; }
+    std::string getSource() const { return _source; }
+    double getValue() const { return _value; }
+    uint64_t getTimestamp() const { return _timestamp; }
+    uint64_t getTtl() const { return _ttl; }
 
-    std::string getElementName(void) const
+    /// topic name (built)
+    std::string generateTopic() const
     {
-        return _element_name;
-    };
+        return _source + "@" + _element_name; // <metric type>@<asset iname>
+    }
 
-    uint64_t getTimestamp(void) const
-    {
-        return _timestamp;
-    };
-
-    bool isUnknown(void) const
-    {
-        if (_element_name.empty() || _source.empty() || _units.empty()) {
-            return true;
-        }
-        return false;
-    };
-
-    uint64_t getTtl(void) const
-    {
-        return _ttl;
-    };
-
-    std::string getUnits(void) const
-    {
-        return _units;
-    };
-
-    std::string getSource(void) const
-    {
-        return _source;
-    };
-    void setTime(void)
-    {
-        _timestamp = static_cast<uint64_t>(::time(NULL));
-    };
-    void setUnits(const std::string& U)
-    {
-        _units = U;
-    };
-    friend inline bool operator==(const MetricInfo& lhs, const MetricInfo& rhs);
-    friend inline bool operator!=(const MetricInfo& lhs, const MetricInfo& rhs);
-
-    // This class is very close to metric info
-    // So let it use fields directly
     friend class MetricList;
 
 private:
-    std::string _element_name;
-    std::string _source;
-    std::string _units;
-    double      _value;
-    uint64_t    _timestamp;
-    std::string _element_destination_name;
-
-    // time to live [s]
-    uint64_t _ttl;
+    std::string _element_name; /// asset iname
+    std::string _source; /// metric type
+    double      _value{0};
+    uint64_t    _timestamp{0}; /// last update (epoch time, sec.)
+    uint64_t    _ttl{0}; /// time to live (sec)
 };
-
-inline bool operator==(const MetricInfo& lhs, const MetricInfo& rhs)
-{
-    return (lhs._units == rhs._units && lhs._value == rhs._value);
-}
-
-inline bool operator!=(const MetricInfo& lhs, const MetricInfo& rhs)
-{
-    return !(lhs == rhs);
-}

--- a/src/metriclist.h
+++ b/src/metriclist.h
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 /// @file metriclist.h
 /// @author Alena Chernikava <AlenaChernikava@Eaton.com>
 /// @brief This class is intended to handle set of current known metrics
+
 #pragma once
 
 #include "metricinfo.h"
@@ -32,11 +33,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 class MetricList
 {
 public:
-    /// Constrocts the empty list
-    MetricList(){};
-
-    /// Destroys the list
-    ~MetricList(){};
+    /// Constructs the empty list
+    MetricList() = default;
 
     /// Adds new metric
     ///
@@ -44,6 +42,20 @@ public:
     /// Also it will update value of last added Metric.
     /// @param[in] metricInfo - metric to add
     void addMetric(const MetricInfo& metricInfo);
+
+    /// Gets the last added metric
+    ///
+    /// @return last added (or updated) metric
+    MetricInfo getLastMetric() const;
+
+    /// Gets metric by the topic
+    /// @param[in] topic - topic we are looking for
+    /// @return MetricInfo       - if metric was found or
+    ///         MetricInfo empty - if metric isn't found
+    MetricInfo getMetricInfo(const std::string& topic) const;
+
+    /// Removes old metrics from the list
+    void removeOldMetrics();
 
     /// Finds a value of the metric in the list and checks if it is still valid.
     ///
@@ -59,24 +71,6 @@ public:
     /// @param[in] topic - topic we are looking for
     /// @return NAN - if metric is not present in the list, value - otherwise
     double find(const std::string& topic) const;
-
-    /// Gets metric by the topic
-    /// @param[in] topic - topic we are looking for
-    /// @return MetricInfo       - if metric was found or
-    ///         MetricInfo empty - if metric isn't found
-    ///                            ( isUnknown() is true)
-    MetricInfo getMetricInfo(const std::string& topic) const;
-
-    /// Removes old metrics from the list
-    void removeOldMetrics(void);
-
-    /// Gets the last added metric
-    ///
-    /// @return last added (or updated) metric
-    MetricInfo getLastMetric(void) const
-    {
-        return _lastInsertedMetric;
-    };
 
 private:
     /// Metric list <topic, Metric>


### PR DESCRIPTION
- reduce MetricInfo memory footprint (remove useless unit & element_destination_name members and related methods)
- simplify MetricList code
- simplify alertconfiguration code
- misc. in fty_alert_engine.cc